### PR TITLE
[fix] 라이트모드에서 스위치 체크시의 thumb 색상이 기본 테마 색상으로 표시되던 현상 수정

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/ui/theme/Color.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/ui/theme/Color.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 val BlackBackground = Color(0xFF111111)
 val BlackSurface = Color(0xFF2A2B2C)
 val Tape = Color(0xFFD8C686)
+val TapeVariant = Color(0xFFB9A461)
 val errorRed = Color(0xFFF15555)
 
 val Gray2 = Color(0xFFEEEEEE)

--- a/presentation/src/main/java/com/strayalphaca/presentation/ui/theme/Theme.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/ui/theme/Theme.kt
@@ -30,16 +30,9 @@ private val LightColorPalette = lightColors(
     onPrimary = Color.Black,
     primaryVariant = Gray2,
     secondary = Tape,
+    secondaryVariant = TapeVariant,
     onError = errorRed
 
-    /* Other default colors to override
-    background = Color.White,
-    surface = Color.White,
-    onPrimary = Color.White,
-    onSecondary = Color.Black,
-    onBackground = Color.Black,
-    onSurface = Color.Black,
-    */
 )
 
 @Composable


### PR DESCRIPTION
- 다크모드에서는 정상적으로 표기되었고, 라이트모드에서만 다르게 표기되었는데, 그 원인은 아래과 같다.
  - switch의 thumb 색상은 secondaryVariant를 사용하는데, 다크모드에서는 secondary색상으로 secondaryVariant를 설정하기에 다크 모드에서는 정상적으로 표기되었다.
  - 반면 light모드는 별도로 secondaryVariant를 설정하지 않으면 기본값 색상을 사용하기 때문에 switch의 thumb색상이 기대했던 secondary색상으로 표기되이 않았다. 

- 따라서 https://colors.eva.design/ 이 사이트를 통해 secondaryVariant색상을 추출하여 라이트 테마의 secondaryVariant를 설정했다.