### PR TITLE
Fix diary

### DIFF
--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/DiaryRepositoryImpl.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/DiaryRepositoryImpl.kt
@@ -47,7 +47,7 @@ class DiaryRepositoryImpl @Inject constructor(
     }
 
     override suspend fun uploadDiary(diaryWriteData: DiaryWriteData): BaseResponse<String> {
-        return BaseResponse.Success(data = "1")
+        return BaseResponse.Success(data = diaryWriteData.recordDate.toString())
     }
 
     override suspend fun modifyDiary(diaryModifyData: DiaryModifyData): BaseResponse<Nothing> {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -189,6 +189,8 @@ fun DiaryDetailScreen(
                     .padding(16.dp)
                     .verticalScroll(scrollState)
                 ) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
                     Text(text = state.diaryDetail.date.toString())
 
                     Spacer(modifier = Modifier.height(16.dp))
@@ -206,17 +208,16 @@ fun DiaryDetailScreen(
                             Text(
                                 text = state.diaryDetail.cityName ?: stringResource(id = R.string.placeholder_location),
                                 style = MaterialTheme.typography.body2,
-                                color = Gray2,
+                                color = MaterialTheme.colors.onSurface,
                                 modifier = Modifier
                                     .align(Alignment.CenterVertically)
                                     .weight(1f)
                                     .padding(end = 10.dp)
                             )
                         }
+
+                        Spacer(modifier = Modifier.height(16.dp))
                     }
-
-
-                    Spacer(modifier = Modifier.height(16.dp))
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.strayalphaca.travel_diary.diary.use_case.UseCaseDeleteDiary
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryDetail
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.presentation.screens.diary.model.MusicPlayer
+import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseHandleCachedCalendarDiary
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -19,6 +20,7 @@ import javax.inject.Inject
 @HiltViewModel
 class DiaryDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val useCaseHandleCachedCalendarDiary: UseCaseHandleCachedCalendarDiary,
     private val useCaseGetDiaryDetail: UseCaseGetDiaryDetail,
     private val useCaseDeleteDiary : UseCaseDeleteDiary,
     private val musicPlayer: MusicPlayer
@@ -162,6 +164,7 @@ class DiaryDetailViewModel @Inject constructor(
                 state.copy(deleteLoading = false)
             }
             DiaryDetailEvent.DeleteDiarySuccess -> {
+                deleteDiaryToCachedDataStore()
                 occurNavigationBack()
                 state.copy(deleteLoading = false)
             }
@@ -174,6 +177,12 @@ class DiaryDetailViewModel @Inject constructor(
     private fun occurNavigationBack() {
         viewModelScope.launch {
             _goBackNavigationEvent.emit(true)
+        }
+    }
+
+    private fun deleteDiaryToCachedDataStore() {
+        viewModelScope.launch {
+            useCaseHandleCachedCalendarDiary.delete(id.value)
         }
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -207,6 +207,8 @@ fun DiaryWriteScreen(
                         .padding(16.dp)
                         .verticalScroll(scrollState)
                 ) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
                     Text(text = state.diaryDate.toString())
 
                     Spacer(modifier = Modifier.height(16.dp))
@@ -223,7 +225,7 @@ fun DiaryWriteScreen(
                         Text(
                             text = state.cityName ?: stringResource(id = R.string.placeholder_location),
                             style = MaterialTheme.typography.body2,
-                            color = Gray2,
+                            color = if (state.cityName != null) MaterialTheme.colors.onSurface else Gray2,
                             modifier = Modifier
                                 .align(Alignment.CenterVertically)
                                 .weight(1f)
@@ -235,9 +237,9 @@ fun DiaryWriteScreen(
                             descriptionText = state.feeling.name,
                             onClick = showLocationPickerDialog
                         )
-                    }
 
-                    Spacer(modifier = Modifier.height(16.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Row(


### PR DESCRIPTION
- 일지 작성/수정/삭제시 실행중 저장하고 있는 달력 데이터에 해당 내역을 반영하도록 수정
- 일지 작성/수정 화면 UI 수정
  - 날짜 Text 부분의 상단 마진 추가
  - 위치가 설정된 이후에서도 글자 색상이 placeHolder의 색상으로 표시되던 문제 수정
  - 위치 미설정시 날짜와 감정 표시 부분 사이의 마진을 축소