### PR TITLE
Fix map

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/MapModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/MapModule.kt
@@ -1,5 +1,7 @@
 package com.strayalphaca.travel_diary.di
 
+import com.strayalphaca.travel_diary.data.map.data_store.MapDataStore
+import com.strayalphaca.travel_diary.data.map.data_store.MapDataStoreImpl
 import com.strayalphaca.travel_diary.data.map.repository.TestMapRepository
 import com.strayalphaca.travel_diary.map.repository.MapRepository
 import dagger.Module
@@ -11,8 +13,13 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object MapModule {
+    @Provides
+    @Singleton
+    fun provideMapRepository(
+        mapDataStore: MapDataStore
+    ) : MapRepository = TestMapRepository(mapDataStore)
 
     @Provides
     @Singleton
-    fun provideMapRepository() : MapRepository = TestMapRepository()
+    fun provideMapDataStore() : MapDataStore = MapDataStoreImpl()
 }

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
@@ -7,7 +7,9 @@ import kotlinx.coroutines.flow.Flow
 interface MapDataStore {
     suspend fun setMapData(locationWithData: LocationWithData)
     fun getMapData() : Flow<LocationWithData>
+    suspend fun getCurrentProvinceId() : Int?
     suspend fun updateDiary(locationDiary: LocationDiary)
     suspend fun deleteDiary(id : String)
+    suspend fun checkContainDiary(id : String) : Boolean
     suspend fun clear()
 }

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
@@ -1,0 +1,13 @@
+package com.strayalphaca.travel_diary.data.map.data_store
+
+import com.strayalphaca.travel_diary.map.model.LocationDiary
+import com.strayalphaca.travel_diary.map.model.LocationWithData
+import kotlinx.coroutines.flow.Flow
+
+interface MapDataStore {
+    suspend fun setMapData(locationWithData: LocationWithData)
+    fun getMapData() : Flow<LocationWithData>
+    suspend fun updateDiary(locationDiary: LocationDiary)
+    suspend fun deleteDiary(id : String)
+    suspend fun clear()
+}

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStore.kt
@@ -1,6 +1,5 @@
 package com.strayalphaca.travel_diary.data.map.data_store
 
-import com.strayalphaca.travel_diary.map.model.LocationDiary
 import com.strayalphaca.travel_diary.map.model.LocationWithData
 import kotlinx.coroutines.flow.Flow
 
@@ -8,8 +7,5 @@ interface MapDataStore {
     suspend fun setMapData(locationWithData: LocationWithData)
     fun getMapData() : Flow<LocationWithData>
     suspend fun getCurrentProvinceId() : Int?
-    suspend fun updateDiary(locationDiary: LocationDiary)
-    suspend fun deleteDiary(id : String)
     suspend fun checkContainDiary(id : String) : Boolean
-    suspend fun clear()
 }

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
@@ -1,0 +1,40 @@
+package com.strayalphaca.travel_diary.data.map.data_store
+
+import com.strayalphaca.travel_diary.map.model.LocationDiary
+import com.strayalphaca.travel_diary.map.model.LocationWithData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import javax.inject.Inject
+
+class MapDataStoreImpl @Inject constructor() : MapDataStore {
+    private val mapWithData = MutableStateFlow(LocationWithData())
+
+    override suspend fun setMapData(locationWithData: LocationWithData) {
+        mapWithData.value = locationWithData
+    }
+
+    override fun getMapData(): Flow<LocationWithData> {
+        return mapWithData
+    }
+
+    override suspend fun updateDiary(locationDiary: LocationDiary) {
+        val diaryList = mapWithData.value.data
+        val targetLocationDiary = diaryList.find{ it.id == locationDiary.id } ?: return
+        val dataList = diaryList.map {
+            if (it.id == targetLocationDiary.id)
+                locationDiary
+            else
+                it
+        }
+        mapWithData.value = mapWithData.value.copy(data = dataList)
+    }
+
+    override suspend fun deleteDiary(id: String) {
+        val dataList = mapWithData.value.data.filter { it.id != id }
+        mapWithData.value = mapWithData.value.copy(data = dataList)
+    }
+
+    override suspend fun clear() {
+        mapWithData.value = LocationWithData()
+    }
+}

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
@@ -1,6 +1,5 @@
 package com.strayalphaca.travel_diary.data.map.data_store
 
-import com.strayalphaca.travel_diary.map.model.LocationDiary
 import com.strayalphaca.travel_diary.map.model.LocationWithData
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,28 +20,8 @@ class MapDataStoreImpl @Inject constructor() : MapDataStore {
         return mapWithData.value.location?.id?.id
     }
 
-    override suspend fun updateDiary(locationDiary: LocationDiary) {
-        val diaryList = mapWithData.value.data
-        val targetLocationDiary = diaryList.find{ it.id == locationDiary.id } ?: return
-        val dataList = diaryList.map {
-            if (it.id == targetLocationDiary.id)
-                locationDiary
-            else
-                it
-        }
-        mapWithData.value = mapWithData.value.copy(data = dataList)
-    }
-
-    override suspend fun deleteDiary(id: String) {
-        val dataList = mapWithData.value.data.filter { it.id != id }
-        mapWithData.value = mapWithData.value.copy(data = dataList)
-    }
-
     override suspend fun checkContainDiary(id: String): Boolean {
         return mapWithData.value.data.find { it.id == id } != null
     }
 
-    override suspend fun clear() {
-        mapWithData.value = LocationWithData()
-    }
 }

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_store/MapDataStoreImpl.kt
@@ -17,6 +17,10 @@ class MapDataStoreImpl @Inject constructor() : MapDataStore {
         return mapWithData
     }
 
+    override suspend fun getCurrentProvinceId(): Int? {
+        return mapWithData.value.location?.id?.id
+    }
+
     override suspend fun updateDiary(locationDiary: LocationDiary) {
         val diaryList = mapWithData.value.data
         val targetLocationDiary = diaryList.find{ it.id == locationDiary.id } ?: return
@@ -32,6 +36,10 @@ class MapDataStoreImpl @Inject constructor() : MapDataStore {
     override suspend fun deleteDiary(id: String) {
         val dataList = mapWithData.value.data.filter { it.id != id }
         mapWithData.value = mapWithData.value.copy(data = dataList)
+    }
+
+    override suspend fun checkContainDiary(id: String): Boolean {
+        return mapWithData.value.data.find { it.id == id } != null
     }
 
     override suspend fun clear() {

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/model/ResponseData.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/model/ResponseData.kt
@@ -13,6 +13,7 @@ data class MapAllLocationResponseBody(
 ) {
     fun toLocationDiary() : LocationDiary =
         LocationDiary(
+            id = id,
             thumbnailUri = image.shortLink ?: image.uploadedLink,
             location = Location(
                 id = LocationId(provinceId),
@@ -30,6 +31,7 @@ data class MapProvinceResponseBody(
 ) {
     fun toLocationDiary(provinceId : Int) : LocationDiary =
         LocationDiary(
+            id = id,
             thumbnailUri = image.shortLink ?: image.uploadedLink,
             location = Location(
                 id = LocationId(groupId),

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/repository/RemoteMapRepository.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/repository/RemoteMapRepository.kt
@@ -3,13 +3,18 @@ package com.strayalphaca.travel_diary.data.map.repository
 import com.strayalphaca.data.all.utils.responseToBaseResponseWithMapping
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.data.map.api.MapApi
+import com.strayalphaca.travel_diary.data.map.data_store.MapDataStore
+import com.strayalphaca.travel_diary.map.model.Location
 import com.strayalphaca.travel_diary.map.model.LocationDiary
+import com.strayalphaca.travel_diary.map.model.LocationWithData
 import com.strayalphaca.travel_diary.map.repository.MapRepository
+import kotlinx.coroutines.flow.Flow
 import retrofit2.Retrofit
 import javax.inject.Inject
 
 class RemoteMapRepository @Inject constructor(
-    retrofit : Retrofit
+    retrofit : Retrofit,
+    private val dataStore: MapDataStore
 ) : MapRepository {
     private val mapRetrofit = retrofit.create(MapApi::class.java)
 
@@ -18,7 +23,10 @@ class RemoteMapRepository @Inject constructor(
         return responseToBaseResponseWithMapping(
             response = response,
             mappingFunction = { it.data.map { responseData -> responseData.toLocationDiary() }}
-        )
+        ).also {
+            if (it is BaseResponse.Success)
+                dataStore.setMapData(LocationWithData(null, it.data))
+        }
     }
 
     override suspend fun getProvinceData(provinceId: Int): BaseResponse<List<LocationDiary>> {
@@ -26,7 +34,24 @@ class RemoteMapRepository @Inject constructor(
         return responseToBaseResponseWithMapping(
             response = response,
             mappingFunction = { it.data.map { responseData -> responseData.toLocationDiary(provinceId) }}
-        )
+        ).also {
+            if (it is BaseResponse.Success)
+                dataStore.setMapData(LocationWithData(Location.getInstanceByProvinceId(provinceId), it.data))
+        }
+    }
+
+    override suspend fun refreshIfContainDiary(diaryId: String) {
+        if (!dataStore.checkContainDiary(diaryId)) return
+        val currentLocationId = dataStore.getCurrentProvinceId()
+        if (currentLocationId == null) {
+            getNationWideData()
+        } else {
+            getProvinceData(currentLocationId)
+        }
+    }
+
+    override fun getLocationWithDataFlow(): Flow<LocationWithData> {
+        return dataStore.getMapData()
     }
 
 }

--- a/domain/map/build.gradle
+++ b/domain/map/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     implementation project(":domain")
     implementation libs.javax.inject
     implementation libs.kotlin.reflection
+    implementation libs.coroutine
 }

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/Location.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/Location.kt
@@ -5,8 +5,19 @@ data class Location(
     val name : String,
     val provinceId : LocationId,
     val type : LocationType = LocationType.PROVINCE
-)
+) {
+    companion object {
+        fun getInstanceByProvinceId(provinceId : Int) : Location {
+            return Location(
+                id = LocationId(provinceId),
+                name = Province.findProvince(provinceId).name,
+                provinceId = LocationId(provinceId),
+                type = LocationType.PROVINCE
+            )
+        }
+    }
+}
 
 enum class LocationType {
-    PROVINCE, CITY_GROUP, CITY
+    PROVINCE, CITY_GROUP
 }

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationDiary.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationDiary.kt
@@ -2,5 +2,6 @@ package com.strayalphaca.travel_diary.map.model
 
 data class LocationDiary(
     val thumbnailUri: String,
-    val location : Location
+    val location : Location,
+    val id : String = ""
 )

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationWithData.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationWithData.kt
@@ -1,0 +1,6 @@
+package com.strayalphaca.travel_diary.map.model
+
+data class LocationWithData(
+    val location : Location? = null,
+    val data : List<LocationDiary> = emptyList()
+)

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/repository/MapRepository.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/repository/MapRepository.kt
@@ -2,8 +2,12 @@ package com.strayalphaca.travel_diary.map.repository
 
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.map.model.LocationDiary
+import com.strayalphaca.travel_diary.map.model.LocationWithData
+import kotlinx.coroutines.flow.Flow
 
 interface MapRepository {
     suspend fun getNationWideData():  BaseResponse<List<LocationDiary>>
     suspend fun getProvinceData(provinceId : Int) : BaseResponse<List<LocationDiary>>
+    suspend fun refreshIfContainDiary(diaryId : String)
+    fun getLocationWithDataFlow() : Flow<LocationWithData>
 }

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/usecase/UseCaseGetMapDiaryList.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/usecase/UseCaseGetMapDiaryList.kt
@@ -2,7 +2,9 @@ package com.strayalphaca.travel_diary.map.usecase
 
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.map.model.LocationDiary
+import com.strayalphaca.travel_diary.map.model.LocationWithData
 import com.strayalphaca.travel_diary.map.repository.MapRepository
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 class UseCaseGetMapDiaryList @Inject constructor(
@@ -14,5 +16,9 @@ class UseCaseGetMapDiaryList @Inject constructor(
 
     suspend fun getProvinceDataList(provinceId : Int) : BaseResponse<List<LocationDiary>> {
         return mapRepository.getProvinceData(provinceId)
+    }
+
+    fun locationWithDataFlow() : Flow<LocationWithData> {
+        return mapRepository.getLocationWithDataFlow()
     }
 }

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/usecase/UseCaseRefreshCachedMap.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/usecase/UseCaseRefreshCachedMap.kt
@@ -1,0 +1,12 @@
+package com.strayalphaca.travel_diary.map.usecase
+
+import com.strayalphaca.travel_diary.map.repository.MapRepository
+import javax.inject.Inject
+
+class UseCaseRefreshCachedMap @Inject constructor(
+    private val repository : MapRepository
+) {
+    suspend operator fun invoke(id : String) {
+        repository.refreshIfContainDiary(diaryId = id)
+    }
+}


### PR DESCRIPTION
- LocationDiary에 diary를 식별하기 위한 id 변수 추가
- Location을 provinceId를 통해 생성하는 로직 추가
- 앱 실행 중 Map관련 데이터를 저장하는 MapDataStore 생성
- Map데이터를 기존 요청 메서드에서 리턴값을 받아 갱신하던 방향에서 flow를 collect하여 반영하는 방식으로 수정
  - domain:map에 coroutine 의존성 추가
  - 이로 인해 repository, useCase에 각각 flow를 리턴하는 메서드가 추가됨
  - viewModel에서 이 flow를 collect할 경우 데이터로드 성공 이벤트를 send하도록 구현
  - 이렇게 구현한 이유는, 일지 수정/삭제시 지도 화면에 표시되는 데이터가 변경될 수 있기에 이를 반영하기 위함
- 앱 실행 중 Map관련 데이터를 갱신하는 useCase 생성