### PR TITLE
Fix login

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/RootActivity.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/RootActivity.kt
@@ -93,7 +93,12 @@ fun RootNavHost(
 
         loginNavGraph(
             navController = navController,
-            onExitLogin = { navController.popBackStack() }
+            onExitLogin = { navController.popBackStack() },
+            navigateToHome = {
+                navController.navigate(HomeGraph.route) {
+                    popUpTo(0) { inclusive = true }
+                }
+            }
         )
 
         composable(

--- a/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
@@ -2,19 +2,24 @@ package com.strayalphaca.travel_diary.di
 
 import com.strayalphaca.travel_diary.data.login.data_source.LoginDataSource
 import com.strayalphaca.travel_diary.data.login.data_source.LoginTestDataSource
-import com.strayalphaca.travel_diary.data.login.repository_impl.LoginRepositoryImpl
+import com.strayalphaca.travel_diary.data.login.repository_impl.RemoteLoginRepository
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
-import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
-abstract class LoginModule {
-    @Binds
-    abstract fun bindLoginRepository(loginRepository: LoginRepositoryImpl) : LoginRepository
+object LoginModule {
+    @Provides
+    fun provideLoginRepository(@BaseClient retrofit: Retrofit) : LoginRepository  {
+        return RemoteLoginRepository(retrofit)
+    }
 
-    @Binds
-    abstract fun bindLoginDataSource(loginDataSource: LoginTestDataSource) : LoginDataSource
+    @Provides
+    fun provideLoginDataSource() : LoginDataSource {
+        return LoginTestDataSource()
+    }
 }

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
@@ -12,16 +12,16 @@ import retrofit2.http.POST
 import retrofit2.http.Query
 
 interface LoginApi {
-    @GET("auths/code")
+    @GET("auth/code")
     suspend fun checkAuthCode(@Query("email") email : String, @Query("code") code : String) : Response<Unit>
 
-    @POST("auths/code")
+    @POST("auth/code")
     suspend fun issueAuthCode(@Body params : IssueAuthCodeBody) : Response<Unit>
 
-    @POST("auths/sign")
+    @POST("auth/signup")
     suspend fun signUpByEmail(@Body params : SignUpRequestBody) : Response<String>
 
-    @POST("auths/login")
+    @POST("auth/login")
     suspend fun login(@Body params : LoginRequestBody) : Response<TokensDto>
 
     @DELETE("users")

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
@@ -3,6 +3,7 @@ package com.strayalphaca.travel_diary.data.login.api
 import com.strayalphaca.travel_diary.data.login.model.IssueAuthCodeBody
 import com.strayalphaca.travel_diary.data.login.model.LoginRequestBody
 import com.strayalphaca.travel_diary.data.login.model.SignUpRequestBody
+import com.strayalphaca.travel_diary.data.login.model.SignupResponseBody
 import com.strayalphaca.travel_diary.data.login.model.TokensDto
 import retrofit2.Response
 import retrofit2.http.Body
@@ -19,7 +20,7 @@ interface LoginApi {
     suspend fun issueAuthCode(@Body params : IssueAuthCodeBody) : Response<Unit>
 
     @POST("auth/signup")
-    suspend fun signUpByEmail(@Body params : SignUpRequestBody) : Response<String>
+    suspend fun signUpByEmail(@Body params : SignUpRequestBody) : Response<SignupResponseBody>
 
     @POST("auth/login")
     suspend fun login(@Body params : LoginRequestBody) : Response<TokensDto>

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/ResponseData.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/ResponseData.kt
@@ -1,3 +1,5 @@
 package com.strayalphaca.travel_diary.data.login.model
 
 data class TokensDto(val accessToken : String, val refreshToken : String)
+
+data class SignupResponseBody(val id : String)

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/LoginRepositoryImpl.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/LoginRepositoryImpl.kt
@@ -23,21 +23,12 @@ class LoginRepositoryImpl @Inject constructor(
         return loginDataSource.postSignup()
     }
 
-    override suspend fun checkEmailDuplication(email: String): BaseResponse<Nothing> {
-        return loginDataSource.getCheckEmail(email)
-    }
-
     override suspend fun checkAuthCode(email : String, authCode: String): BaseResponse<Nothing> {
         return loginDataSource.getAuthCode(email, authCode)
     }
 
     override suspend fun issueAuthCode(email : String): BaseResponse<Nothing> {
         return loginDataSource.postAuthCode(email)
-    }
-
-    override suspend fun refreshToken(): BaseResponse<Tokens> {
-        val response = loginDataSource.postRefresh()
-        return mapBaseResponse(response, ::tokenDtoToToken)
     }
 
     override suspend fun withdrawal(): BaseResponse<Nothing> {

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
@@ -1,6 +1,5 @@
 package com.strayalphaca.travel_diary.data.login.repository_impl
 
-import com.strayalphaca.data.all.utils.responseToBaseResponse
 import com.strayalphaca.data.all.utils.responseToBaseResponseWithMapping
 import com.strayalphaca.data.all.utils.voidResponseToBaseResponse
 import com.strayalphaca.travel_diary.data.login.api.LoginApi
@@ -11,6 +10,7 @@ import com.strayalphaca.travel_diary.data.login.utils.tokenDtoToToken
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.login.utils.extractIdFromSignupResponse
 import retrofit2.Retrofit
 import javax.inject.Inject
 
@@ -29,7 +29,10 @@ class RemoteLoginRepository @Inject constructor(
 
     override suspend fun emailSignup(email: String, password: String): BaseResponse<String> {
         val response = loginRetrofit.signUpByEmail(SignUpRequestBody(email = email, password = password))
-        return responseToBaseResponse(response)
+        return responseToBaseResponseWithMapping(
+            response = response,
+            mappingFunction = ::extractIdFromSignupResponse
+        )
     }
 
     override suspend fun checkAuthCode(email: String, authCode: String): BaseResponse<Nothing> {

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
@@ -32,10 +32,6 @@ class RemoteLoginRepository @Inject constructor(
         return responseToBaseResponse(response)
     }
 
-    override suspend fun checkEmailDuplication(email: String): BaseResponse<Nothing> {
-        TODO("Not yet implemented")
-    }
-
     override suspend fun checkAuthCode(email: String, authCode: String): BaseResponse<Nothing> {
         val response = loginRetrofit.checkAuthCode(email, authCode)
         return voidResponseToBaseResponse(response)
@@ -44,10 +40,6 @@ class RemoteLoginRepository @Inject constructor(
     override suspend fun issueAuthCode(email: String): BaseResponse<Nothing> {
         val response = loginRetrofit.issueAuthCode(IssueAuthCodeBody(email))
         return voidResponseToBaseResponse(response)
-    }
-
-    override suspend fun refreshToken(): BaseResponse<Tokens> {
-        TODO("Not yet implemented")
     }
 
     override suspend fun withdrawal(): BaseResponse<Nothing> {

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/utils/Mapper.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/utils/Mapper.kt
@@ -1,5 +1,6 @@
 package com.strayalphaca.travel_diary.data.login.utils
 
+import com.strayalphaca.travel_diary.data.login.model.SignupResponseBody
 import com.strayalphaca.travel_diary.data.login.model.TokensDto
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 
@@ -8,4 +9,8 @@ fun tokenDtoToToken(tokensDto: TokensDto) : Tokens {
         accessToken = tokensDto.accessToken,
         refreshToken = tokensDto.refreshToken
     )
+}
+
+fun extractIdFromSignupResponse(signupResponseBody: SignupResponseBody) : String {
+    return signupResponseBody.id
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/LoginErrorCodes.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/LoginErrorCodes.kt
@@ -1,0 +1,10 @@
+package com.strayalphaca.travel_diary.domain.login.model
+
+object LoginErrorCodes {
+    const val INPUT_EMAIL_AND_PASSWORD = 1
+    const val INVALID_EMAIL_FORMAT = 2
+    const val EXIST_EMAIL = 3
+    const val INVALID_EMAIL_OR_PASSWORD = 4
+    const val DAILY_LIMIT_EXCEEDED_ISSUE_AUTH_CODE = 5
+    const val INVALID_AUTH_CODE = 5
+}

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/repository/LoginRepository.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/repository/LoginRepository.kt
@@ -6,9 +6,7 @@ import com.strayalphaca.domain.model.BaseResponse
 interface LoginRepository {
     suspend fun emailLogin(email : String, password : String) : BaseResponse<Tokens>
     suspend fun emailSignup(email : String, password : String) : BaseResponse<String>
-    suspend fun checkEmailDuplication(email : String) : BaseResponse<Nothing>
     suspend fun checkAuthCode(email : String, authCode : String) : BaseResponse<Nothing>
     suspend fun issueAuthCode(email : String) : BaseResponse<Nothing>
-    suspend fun refreshToken() : BaseResponse<Tokens>
     suspend fun withdrawal() : BaseResponse<Nothing>
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -2,12 +2,18 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
+import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import javax.inject.Inject
 
 class UseCaseIssueAuthCode @Inject constructor(
     private val repository: LoginRepository
 ) {
     suspend operator fun invoke(email : String) : BaseResponse<Nothing> {
+        if (!isEmailFormat(email)) {
+            return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
+        }
+
         return repository.issueAuthCode(email)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -12,10 +12,6 @@ class UseCaseIssueAuthCode @Inject constructor(
     }
 
     suspend fun withEmailCheck(email : String) : BaseResponse<Nothing> {
-        val checkEmailResponse = repository.checkEmailDuplication(email)
-
-        if (checkEmailResponse is BaseResponse.Failure) return checkEmailResponse
-
         return repository.issueAuthCode(email)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -10,8 +10,4 @@ class UseCaseIssueAuthCode @Inject constructor(
     suspend operator fun invoke(email : String) : BaseResponse<Nothing> {
         return repository.issueAuthCode(email)
     }
-
-    suspend fun withEmailCheck(email : String) : BaseResponse<Nothing> {
-        return repository.issueAuthCode(email)
-    }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
@@ -3,12 +3,21 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
+import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import javax.inject.Inject
 
 class UseCaseLogin @Inject constructor(
     private val repository : LoginRepository
 ) {
     suspend operator fun invoke(email : String, password : String) : BaseResponse<Tokens> {
+        if (email.isEmpty() || password.isEmpty()) {
+            return BaseResponse.Failure(errorCode = LoginErrorCodes.INPUT_EMAIL_AND_PASSWORD, errorMessage = "이메일/비밀번호를 입력해 주세요.")
+        }
+        if (!isEmailFormat(email)) {
+            return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
+        }
+
         return repository.emailLogin(email, password)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/utils/checkFormat.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/utils/checkFormat.kt
@@ -1,0 +1,6 @@
+package com.strayalphaca.travel_diary.domain.login.utils
+
+fun isEmailFormat(email: String): Boolean {
+    val emailPattern = Regex("[a-zA-Z0-9._-]+@[a-z]+\\.+[a-z]+")
+    return emailPattern.matches(email)
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
@@ -66,9 +66,8 @@ fun EditTextWithTitle(
             decorationBox = { innerTextField ->
                 if (value.isEmpty()) {
                     Text(text = placeHolder, color = Gray4, fontSize = 14.sp)
-                } else {
-                    innerTextField()
                 }
+                innerTextField()
             },
             keyboardOptions = KeyboardOptions(keyboardType = keyboardType)
         )

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/LoginHomeNavGraph.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/LoginHomeNavGraph.kt
@@ -22,7 +22,8 @@ private fun NavHostController.navigateSingleTopTo(route : String) =
 
 fun NavGraphBuilder.loginNavGraph(
     navController: NavHostController,
-    onExitLogin : () -> Unit = {}
+    onExitLogin : () -> Unit = {},
+    navigateToHome : () -> Unit = {}
 ) {
     navigation(
         route = "login_graph",
@@ -33,6 +34,7 @@ fun NavGraphBuilder.loginNavGraph(
             LoginScreen(
                 navigateToBack = onExitLogin,
                 navigateToSignup = {navController.navigate(SignupScreenDestination.route)},
+                navigateToHome = navigateToHome,
                 viewModel = loginViewModel
             )
         }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginScreen.kt
@@ -20,17 +20,27 @@ import com.strayalphaca.presentation.components.atom.text_button.TextButton
 import com.strayalphaca.presentation.components.block.EditTextWithTitle
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import com.strayalphaca.presentation.components.block.EditTextType
+import com.strayalphaca.presentation.utils.collectAsEffect
 
 @Composable
 fun LoginScreen(
     navigateToSignup : () -> Unit = {},
     navigateToBack : () -> Unit = {},
+    navigateToHome : () -> Unit = {},
     viewModel : LoginViewModel = viewModel()
 ) {
     val email by viewModel.email.collectAsState()
     val password by viewModel.password.collectAsState()
     val loginLoading by viewModel.networkLoading.collectAsState()
+    val errorMessage by viewModel.errorMessage.collectAsState()
+
+    viewModel.loginSuccess.collectAsEffect { success ->
+        if (success) {
+            navigateToHome()
+        }
+    }
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -82,11 +92,21 @@ fun LoginScreen(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                TextButton(
-                    text = stringResource(id = R.string.signup),
-                    modifier = Modifier.align(Alignment.End),
-                    onClick = navigateToSignup
-                )
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    Text(
+                        modifier = Modifier.padding(vertical = 12.dp),
+                        text = errorMessage,
+                        style = MaterialTheme.typography.body2.copy(color = Color.Red)
+                    )
+
+                    Spacer(modifier = Modifier.weight(1f))
+                    Spacer(modifier = Modifier.width(12.dp))
+
+                    TextButton(
+                        text = stringResource(id = R.string.signup),
+                        onClick = navigateToSignup
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.weight(1f))

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
@@ -3,6 +3,8 @@ package com.strayalphaca.presentation.screens.login_home.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseSaveToken
+import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseLogin
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -14,7 +16,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val useCaseLogin: UseCaseLogin
+    private val useCaseLogin: UseCaseLogin,
+    private val useCaseSaveToken: UseCaseSaveToken
 ) : ViewModel() {
     private val _email = MutableStateFlow("")
     val email = _email.asStateFlow()
@@ -47,6 +50,8 @@ class LoginViewModel @Inject constructor(
             if (response is BaseResponse.Failure) {
                 _errorMessage.value = response.errorMessage
             } else {
+                response as BaseResponse.Success<Tokens>
+                useCaseSaveToken(response.data.accessToken, response.data.refreshToken)
                 _loginSuccess.emit(true)
             }
             _networkLoading.value = false

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
@@ -2,9 +2,12 @@ package com.strayalphaca.presentation.screens.login_home.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseLogin
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,6 +25,12 @@ class LoginViewModel @Inject constructor(
     private val _networkLoading = MutableStateFlow(false)
     val networkLoading = _networkLoading.asStateFlow()
 
+    private val _errorMessage = MutableStateFlow("")
+    val errorMessage = _errorMessage.asStateFlow()
+
+    private val _loginSuccess = MutableSharedFlow<Boolean>()
+    val loginSuccess = _loginSuccess.asSharedFlow()
+
     fun inputEmail(email : String) {
         _email.value = email
     }
@@ -33,7 +42,13 @@ class LoginViewModel @Inject constructor(
     fun tryLogin() {
         viewModelScope.launch {
             _networkLoading.value = true
+            _errorMessage.value = ""
             val response = useCaseLogin(email = email.value, password = password.value)
+            if (response is BaseResponse.Failure) {
+                _errorMessage.value = response.errorMessage
+            } else {
+                _loginSuccess.emit(true)
+            }
             _networkLoading.value = false
         }
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/singup_email/SignupEmailViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/singup_email/SignupEmailViewModel.kt
@@ -83,7 +83,7 @@ class SignupEmailViewModel @Inject constructor(
     fun tryCheckAndIssueAuthCode() {
         viewModelScope.launch {
             _viewState.value = SignupEmailViewState.IssuingAuthCodeStep
-            val response = useCaseIssueAuthCode.withEmailCheck(email.value)
+            val response = useCaseIssueAuthCode(email.value)
 
             // 이메일 중복검사 및 인증번호 발급 성공시 타이머 실행
             if (response is BaseResponse.EmptySuccess) {


### PR DESCRIPTION
로그인 관련 아래 기능들을 수정했습니다.
- 로그인 관련 api의 url 경로를 수정했습니다.
- 로그인 관련 repository를 테스트 구현체에서 실제 구현체를 사용하도록 변경
- repository, usecase에서 일부 미사용 함수 제거
- 로그인 화면에서 로그인 성공시 홈 화면으로 이동하는 로직 추가
- 로그인 성공시 accessToken, refreshToken을 저장하는 로직 연결
- 로그인관련 UI에서 사용하는 BasicTextField의 decorationBox에서 innerTextField를 항상 리턴하도록 변경 
(layoutcoordinate operations are only valid when isattached is true)