### PR TITLE
[feature] viewModel에서 문자열 리소스를 사용하기 위해 UiText 클래스 선언

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/models/UiText.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/UiText.kt
@@ -1,0 +1,40 @@
+package com.strayalphaca.presentation.models
+
+import android.content.Context
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+
+sealed class UiText{
+    class StringResource(
+        @StringRes val resourceId : Int
+    ) : UiText()
+
+    class StringResourceWithArgs(
+        @StringRes val resourceId: Int,
+        vararg val args : Any
+    ) : UiText()
+
+    @Composable
+    fun asString() : String {
+        return when(this) {
+            is StringResource -> {
+                stringResource(resourceId)
+            }
+            is StringResourceWithArgs -> {
+                stringResource(resourceId, *args)
+            }
+        }
+    }
+
+    fun asString(context : Context) : String {
+        return when(this) {
+            is StringResource -> {
+                context.getString(resourceId)
+            }
+            is StringResourceWithArgs -> {
+                context.getString(resourceId, *args)
+            }
+        }
+    }
+}


### PR DESCRIPTION
- 향후 에러 코드에 대한 메세지를 UI에 표시할 때, 문자열 리소를 사용하게 되는데, viewModel에서는 context를 참조해서는 안되기 때문에 문자열 리소스를 처리하는 UiText 클래스를 정의