### PR TITLE
Fix diary

### DIFF
--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
@@ -5,6 +5,7 @@ import com.strayalphaca.data.all.model.DiaryItemDto
 import com.strayalphaca.data.all.model.ListResponseData
 import com.strayalphaca.travel_diary.data.diary.model.ModifyDiaryRequestBody
 import com.strayalphaca.travel_diary.data.diary.model.UploadDiaryRequestBody
+import com.strayalphaca.travel_diary.data.diary.model.UploadResponseBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -16,7 +17,7 @@ import retrofit2.http.Query
 
 interface DiaryApi {
     @POST("records")
-    suspend fun uploadDiary(@Body params : UploadDiaryRequestBody) : Response<String>
+    suspend fun uploadDiary(@Body params : UploadDiaryRequestBody) : Response<UploadResponseBody>
 
     @GET("records/{record}")
     suspend fun loadDetailDiary(@Path("record") record : String) : Response<DiaryDto>

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/model/ResponseBody.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/model/ResponseBody.kt
@@ -1,0 +1,3 @@
+package com.strayalphaca.travel_diary.data.diary.model
+
+data class UploadResponseBody(val id : String)

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
@@ -1,6 +1,5 @@
 package com.strayalphaca.travel_diary.data.diary.repository_impl
 
-import com.strayalphaca.data.all.utils.responseToBaseResponse
 import com.strayalphaca.data.all.utils.responseToBaseResponseWithMapping
 import com.strayalphaca.data.all.utils.voidResponseToBaseResponse
 import com.strayalphaca.travel_diary.data.diary.api.DiaryApi
@@ -14,6 +13,7 @@ import com.strayalphaca.travel_diary.diary.model.DiaryModifyData
 import com.strayalphaca.travel_diary.diary.model.DiaryWriteData
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.diary.utils.extractIdFromSignupResponse
 import retrofit2.Retrofit
 import javax.inject.Inject
 
@@ -54,7 +54,7 @@ class RemoteDiaryRepository @Inject constructor(
 
     override suspend fun uploadDiary(diaryWriteData: DiaryWriteData): BaseResponse<String> {
         val response = diaryRetrofit.uploadDiary(params = UploadDiaryRequestBody.fromDiaryWriteData(diaryWriteData))
-        return responseToBaseResponse(response)
+        return responseToBaseResponseWithMapping(response, ::extractIdFromSignupResponse)
     }
 
     override suspend fun modifyDiary(diaryModifyData: DiaryModifyData): BaseResponse<Nothing> {

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
@@ -5,6 +5,7 @@ import com.strayalphaca.data.all.model.DiaryItemDto
 import com.strayalphaca.data.all.model.MediaFileInfoDto
 import com.strayalphaca.data.all.model.VoiceFileInDiaryDto
 import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.travel_diary.data.diary.model.UploadResponseBody
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.model.DiaryItem
 import com.strayalphaca.travel_diary.diary.model.Feeling
@@ -82,4 +83,8 @@ fun voiceFileInFileDtoToFile(voiceFileInDiaryDto: VoiceFileInDiaryDto) : File {
         type = FileType.VOICE,
         thumbnailLink = null
     )
+}
+
+fun extractIdFromSignupResponse(uploadResponseBody: UploadResponseBody) : String {
+    return uploadResponseBody.id
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/model/DiaryErrorCodes.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/model/DiaryErrorCodes.kt
@@ -1,0 +1,6 @@
+package com.strayalphaca.travel_diary.diary.model
+
+object DiaryErrorCodes {
+    const val EMPTY_ARGUMENT_DIARY_CONTENT = 1
+    const val ALREADY_EXIST_TODAY_DIARY = 2
+}

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseModifyDiary.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseModifyDiary.kt
@@ -3,12 +3,17 @@ package com.strayalphaca.travel_diary.diary.use_case
 import com.strayalphaca.travel_diary.diary.model.DiaryModifyData
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.diary.model.DiaryErrorCodes
 import javax.inject.Inject
 
 class UseCaseModifyDiary @Inject constructor(
     private val repository: DiaryRepository
 ) {
     suspend operator fun invoke(diaryModifyData: DiaryModifyData) : BaseResponse<Nothing> {
+        if (diaryModifyData.content == "") {
+            return BaseResponse.Failure(errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT, errorMessage = "")
+        }
+
         return repository.modifyDiary(diaryModifyData)
     }
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseUploadDiary.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseUploadDiary.kt
@@ -3,12 +3,17 @@ package com.strayalphaca.travel_diary.diary.use_case
 import com.strayalphaca.travel_diary.diary.model.DiaryWriteData
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.diary.model.DiaryErrorCodes
 import javax.inject.Inject
 
 class UseCaseUploadDiary @Inject constructor(
     private val repository: DiaryRepository
 ) {
     suspend operator fun invoke(diaryWriteData: DiaryWriteData) : BaseResponse<String> {
+        if (diaryWriteData.content.isEmpty()) {
+            return BaseResponse.Failure(errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT, errorMessage = "")
+        }
+
         return repository.uploadDiary(diaryWriteData)
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import com.strayalphaca.presentation.components.atom.text_button.TextButtonState
 import com.strayalphaca.presentation.components.template.dialog.DiaryLocationPickerDialog
 import com.strayalphaca.presentation.components.template.error_view.ErrorView
 import com.strayalphaca.travel_diary.diary.model.Feeling
@@ -188,6 +189,7 @@ fun DiaryWriteScreen(
                 TextButton(
                     modifier = Modifier.padding(horizontal = 16.dp),
                     text = stringResource(id = R.string.register),
+                    state = if (content.isEmpty()) TextButtonState.INACTIVE else TextButtonState.ACTIVE,
                     onClick = uploadDiary
                 )
             }


### PR DESCRIPTION
- 일지 관련 api의 응답 형식을 Response<String>에서 각 api의 응답 형식을 Response<UploadResponseBody>로 변경
- 일지 작성시 작성된 내용이 없는 경우 작성 버튼이 비활성화 되도록 수정
- 일자 작성시 발생할 수 있는 에러 코드 선언