### PR TITLE
[fix] EditTextWithTitle의 TextField 커서 색상을 다크 모드에서 흰색으로 보이도록 수정

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
@@ -17,6 +17,7 @@ import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -69,7 +70,8 @@ fun EditTextWithTitle(
                 }
                 innerTextField()
             },
-            keyboardOptions = KeyboardOptions(keyboardType = keyboardType)
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            cursorBrush = SolidColor(MaterialTheme.colors.onSurface)
         )
         Box(
             modifier = Modifier


### PR DESCRIPTION
로그인/회원가입 화면에서 확인 가능