### PR TITLE
Fix calendar

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/CalendarModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/CalendarModule.kt
@@ -2,14 +2,18 @@ package com.strayalphaca.travel_diary.di
 
 import com.strayalphaca.travel_diary.data.calendar.data_source.CalendarDataSource
 import com.strayalphaca.travel_diary.data.calendar.data_source.CalendarTestDataSource
+import com.strayalphaca.travel_diary.data.calendar.data_source.RemoteCalendarDataSource
 import com.strayalphaca.travel_diary.data.calendar.data_store.CalendarDataStore
 import com.strayalphaca.travel_diary.data.calendar.data_store.CalendarDataStoreImpl
 import com.strayalphaca.travel_diary.data.calendar.repository_impl.CalendarRepositoryImpl
+import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import com.strayalphaca.travel_diary.domain.calendar.repository.CalendarRepository
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -18,8 +22,22 @@ abstract class CalendarModule {
     abstract fun bindCalendarRepository(calendarRepository: CalendarRepositoryImpl) : CalendarRepository
 
     @Binds
-    abstract fun bindCalendarDataSource(calendarDataSource: CalendarTestDataSource) : CalendarDataSource
-
-    @Binds
     abstract fun bindCalendarDataStore(calendarDataStore: CalendarDataStoreImpl) : CalendarDataStore
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object CalendarProvideModule {
+    @Provides
+    fun provideCalendarDataSource(
+        @BaseClient retrofit : Retrofit,
+        authRepository: AuthRepository
+    ) : CalendarDataSource {
+        val hasToken = authRepository.getAccessToken() != null
+        return if (hasToken) {
+            RemoteCalendarDataSource(retrofit)
+        } else {
+            CalendarTestDataSource()
+        }
+    }
 }

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/api/CalendarApi.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/api/CalendarApi.kt
@@ -4,11 +4,12 @@ import com.strayalphaca.data.all.model.ListResponseData
 import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface CalendarApi {
     @GET("records/calendar")
-    suspend fun getDiaryOfMonth(year : Int, month : Int) : Response<ListResponseData<CalendarDiaryDto>>
+    suspend fun getDiaryOfMonth(@Query("year") year : Int, @Query("month") month : Int) : Response<ListResponseData<CalendarDiaryDto>>
 
     @GET("records/exists")
-    suspend fun checkRecordExists(recordDate : String) : Response<Nothing>
+    suspend fun checkRecordExists(@Query("recordDate") recordDate : String) : Response<Unit>
 }

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/api/CalendarApi.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/api/CalendarApi.kt
@@ -1,0 +1,14 @@
+package com.strayalphaca.travel_diary.data.calendar.api
+
+import com.strayalphaca.data.all.model.ListResponseData
+import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface CalendarApi {
+    @GET("records/calendar")
+    suspend fun getDiaryOfMonth(year : Int, month : Int) : Response<ListResponseData<CalendarDiaryDto>>
+
+    @GET("records/exists")
+    suspend fun checkRecordExists(recordDate : String) : Response<Nothing>
+}

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarDataSource.kt
@@ -1,9 +1,9 @@
 package com.strayalphaca.travel_diary.data.calendar.data_source
 
-import com.strayalphaca.data.all.model.DiaryDto
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
 
 interface CalendarDataSource {
-    suspend fun getDiaryData(year : Int, month : Int) : BaseResponse<List<DiaryDto>>
+    suspend fun getDiaryData(year : Int, month : Int) : BaseResponse<List<CalendarDiaryDto>>
     suspend fun checkWrittenOnToday() : BaseResponse<Boolean>
 }

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarTestDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarTestDataSource.kt
@@ -1,19 +1,18 @@
 package com.strayalphaca.travel_diary.data.calendar.data_source
 
-import com.strayalphaca.data.all.model.DiaryDto
-import com.strayalphaca.data.all.model.MediaFileInfoDto
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
+import java.text.DecimalFormat
 import javax.inject.Inject
 
 class CalendarTestDataSource @Inject constructor(): CalendarDataSource {
-    override suspend fun getDiaryData(year: Int, month: Int): BaseResponse<List<DiaryDto>> {
+    override suspend fun getDiaryData(year: Int, month: Int): BaseResponse<List<CalendarDiaryDto>> {
+        val decimalFormat = DecimalFormat("00")
+        val formatMonth = decimalFormat.format(month)
         val diaryData = listOf(
-            DiaryDto(id = "${year}_${month}_1", date = "${year}/${month}.01",
-                medias = listOf(MediaFileInfoDto(originName = "", shortLink = "",))).apply { dateStringFormat = "yyyy/MM.dd" },
-            DiaryDto(id = "${year}_${month}_2", date = "${year}/${month}.13",
-                medias = listOf(MediaFileInfoDto(originName = "", shortLink = "",))).apply { dateStringFormat = "yyyy/MM.dd" },
-            DiaryDto(id = "${year}_${month}_3", date = "${year}/${month}.25",
-                medias = listOf(MediaFileInfoDto(originName = "", shortLink = "",))).apply { dateStringFormat = "yyyy/MM.dd" }
+            CalendarDiaryDto(id = "${year}_${formatMonth}_1", recordDate = "${year}/${formatMonth}.01", image = null).apply { dateStringFormat = "yyyy/MM.dd" },
+            CalendarDiaryDto(id = "${year}_${formatMonth}_2", recordDate = "${year}/${formatMonth}.13", image = null).apply { dateStringFormat = "yyyy/MM.dd" },
+            CalendarDiaryDto(id = "${year}_${formatMonth}_3", recordDate = "${year}/${formatMonth}.25", image = null).apply { dateStringFormat = "yyyy/MM.dd" }
         )
 
         return BaseResponse.Success(data = diaryData)

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
@@ -1,0 +1,28 @@
+package com.strayalphaca.travel_diary.data.calendar.data_source
+
+import com.strayalphaca.data.all.utils.responseToBaseResponseWithMapping
+import com.strayalphaca.data.all.utils.voidResponseToBaseResponse
+import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.calendar.api.CalendarApi
+import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
+import retrofit2.Retrofit
+import javax.inject.Inject
+
+class RemoteCalendarDataSource @Inject constructor(
+    retrofit: Retrofit
+) : CalendarDataSource {
+    private val calendarRetrofit = retrofit.create(CalendarApi::class.java)
+
+    override suspend fun getDiaryData(year: Int, month: Int): BaseResponse<List<CalendarDiaryDto>> {
+        val response = calendarRetrofit.getDiaryOfMonth(year, month)
+        return responseToBaseResponseWithMapping(response) {it.data}
+    }
+
+    override suspend fun checkWrittenOnToday(): BaseResponse<Boolean> {
+        val todayDateString = DiaryDate.getInstanceFromCalendar()
+        val response = calendarRetrofit.checkRecordExists(todayDateString.toString())
+        return voidResponseToBaseResponse(response)
+    }
+
+}

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
@@ -8,7 +8,9 @@ import com.strayalphaca.travel_diary.data.calendar.api.CalendarApi
 import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
 import retrofit2.Retrofit
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class RemoteCalendarDataSource @Inject constructor(
     retrofit: Retrofit
 ) : CalendarDataSource {

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/models/CalendarDiaryDto.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/models/CalendarDiaryDto.kt
@@ -1,0 +1,21 @@
+package com.strayalphaca.travel_diary.data.calendar.models
+
+import com.strayalphaca.data.all.model.ImageDto
+import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
+
+data class CalendarDiaryDto(
+    val id : String,
+    val image : ImageDto?,
+    val recordDate : String
+) {
+    var dateStringFormat : String = "yyyy-MM-dd"
+
+    fun toDiaryInCalendar() : DiaryInCalendar {
+        return DiaryInCalendar(
+            id = id,
+            thumbnailUrl = image?.shortLink ?: image?.uploadedLink,
+            date = DiaryDate.getInstanceFromDateStringBySimpleDateFormat(recordDate, dateStringFormat)
+        )
+    }
+}

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/repository_impl/CalendarRepositoryImpl.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/repository_impl/CalendarRepositoryImpl.kt
@@ -4,7 +4,6 @@ import com.strayalphaca.travel_diary.data.calendar.data_source.CalendarDataSourc
 import com.strayalphaca.travel_diary.domain.calendar.repository.CalendarRepository
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.data.calendar.data_store.CalendarDataStore
-import com.strayalphaca.travel_diary.data.calendar.utils.diaryDtoToDiaryInCalendar
 import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
 import com.strayalphaca.travel_diary.domain.calendar.model.MonthCalendar
 import kotlinx.coroutines.flow.Flow
@@ -20,7 +19,7 @@ class CalendarRepositoryImpl @Inject constructor(
             calendarDataStore.setCalendarData(
                 year = year,
                 month = month,
-                dataList = response.data.map { diaryDtoToDiaryInCalendar(it) }
+                dataList = response.data.map { it.toDiaryInCalendar() }
             )
             BaseResponse.EmptySuccess
         } else {


### PR DESCRIPTION
- 달력 api 연동을 위한 아래 작업 수행
  - 해당 api에서 사용하는 달력 일지 dto객체 선언
  - CalendarDataSource인터페이스에서 getDiary 메서드의 리턴값을 DiaryDto가 아닌 위에서 선언한 Dto를 사용하도록 수정
  - 서버 api를 사용하는 CalendarDataSource 구현체 생성
  - 위에서 생성한 구현체를 로그인한 경우에 주입하도록 DI 수정, 만약 로그인하지 않은 경우 기존에 사용하던 DataSrouce를 주입