### PR TITLE
Fix calendar

### DIFF
--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
@@ -1,7 +1,6 @@
 package com.strayalphaca.travel_diary.data.calendar.data_source
 
 import com.strayalphaca.data.all.utils.responseToBaseResponseWithMapping
-import com.strayalphaca.data.all.utils.voidResponseToBaseResponse
 import com.strayalphaca.domain.all.DiaryDate
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.data.calendar.api.CalendarApi
@@ -24,7 +23,19 @@ class RemoteCalendarDataSource @Inject constructor(
     override suspend fun checkWrittenOnToday(): BaseResponse<Boolean> {
         val todayDateString = DiaryDate.getInstanceFromCalendar()
         val response = calendarRetrofit.checkRecordExists(todayDateString.toString())
-        return voidResponseToBaseResponse(response)
+
+        val baseResponse = when {
+            response.isSuccessful && response.code() == 200 -> {
+                BaseResponse.Success(data = true)
+            }
+            response.isSuccessful && response.code() != 200 -> {
+                BaseResponse.Success(data = false)
+            }
+            else -> {
+                BaseResponse.Failure(errorCode = response.code(), errorMessage = response.message())
+            }
+        }
+        return baseResponse
     }
 
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
@@ -93,7 +93,7 @@ class CalendarViewModel @Inject constructor(
                 state.copy(clickEnable = false)
             }
             is CalendarViewEvent.SuccessCheckingTodayWritten -> {
-                if (!event.written) {
+                if (event.writable) {
                     callGoDiaryWriteNavigationEvent()
                 } else {
                     makeToast()
@@ -119,6 +119,6 @@ sealed class CalendarViewEvent{
     class SuccessLoadDiaryData(val year : Int, val month : Int, val diaryData : List<DiaryInCalendar?>) : CalendarViewEvent()
     object FailureLoadDiaryData : CalendarViewEvent()
     object CheckingTodayWritten : CalendarViewEvent()
-    class SuccessCheckingTodayWritten(val written : Boolean) : CalendarViewEvent()
+    class SuccessCheckingTodayWritten(val writable : Boolean) : CalendarViewEvent()
     object FailureCheckingTodayWritten : CalendarViewEvent()
 }


### PR DESCRIPTION
- 달력 화면에서 사용되는 당일 일지 작성 여부 확인 기능관련 아래 부분을 수정
  - dataSorce에서 BaseResponse<Nothing>을 리턴하고 있었는데, 이 부분을 BaseResponse<Boolean>을 리턴하도록 수정
  - viewModel에서 작성여부 검사 response의 boolean 데이터값의 의미를 "이미 작성했는지 여부"에서 "작성 가능한지 여부"로 변경, 이로 인해서 viewModel에서 해당 이벤트를 처리하는 부분에서 if문 조건에 ! 연산을 제거함