### PR TITLE
Fix diary

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
@@ -3,18 +3,37 @@ package com.strayalphaca.travel_diary.di
 import com.strayalphaca.travel_diary.data.diary.data_source.DiaryDataSource
 import com.strayalphaca.travel_diary.data.diary.data_source.DiaryTestDataSource
 import com.strayalphaca.travel_diary.data.diary.repository_impl.DiaryRepositoryImpl
+import com.strayalphaca.travel_diary.data.diary.repository_impl.RemoteDiaryRepository
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
+import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class DiaryModule {
     @Binds
-    abstract fun bindDiaryRepository(diaryRepository: DiaryRepositoryImpl) : DiaryRepository
-
-    @Binds
     abstract fun bindDiaryDataSource(diaryDataSource: DiaryTestDataSource) : DiaryDataSource
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DiaryProvideModule {
+    @Provides
+    fun provideDiaryRepository(
+        @BaseClient retrofit : Retrofit,
+        authRepository: AuthRepository,
+        diaryDataSource: DiaryTestDataSource
+    ) : DiaryRepository {
+        val hasToken = authRepository.getAccessToken() != null
+        return if (hasToken) {
+            RemoteDiaryRepository(retrofit)
+        } else {
+            DiaryRepositoryImpl(diaryDataSource)
+        }
+    }
 }

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
@@ -28,9 +28,9 @@ interface DiaryApi {
     @PATCH("records/{recordId}")
     suspend fun modifyDiary(@Path("recordId") recordId : String, @Body params : ModifyDiaryRequestBody) : Response<Unit>
 
-    @GET("map")
+    @GET("records/map")
     suspend fun loadDiaryList(@Query("cityId") cityId : Int, @Query("page") page : Int, @Query("offset") offset : Int) : Response<ListResponseData<DiaryItemDto>>
 
-    @GET("map")
+    @GET("records/map")
     suspend fun loadDiaryListByCityGroup(@Query("cityGroupId") cityGroupId : Int, @Query("page") page : Int, @Query("offset") offset : Int) : Response<ListResponseData<DiaryItemDto>>
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -46,6 +46,7 @@ import com.strayalphaca.domain.all.DiaryDate
 import com.strayalphaca.presentation.screens.diary.component.ContentIconImage
 import com.strayalphaca.presentation.screens.diary.util.getFeelingIconId
 import com.strayalphaca.presentation.screens.diary.util.getWeatherIconId
+import com.strayalphaca.presentation.utils.collectAsEffect
 
 @Composable
 fun DiaryDetailContainer(
@@ -59,14 +60,13 @@ fun DiaryDetailContainer(
 ) {
     val state by viewModel.state.collectAsState()
     val musicProgress by viewModel.musicProgress.collectAsState()
-    val deleteSuccess by viewModel.goBackNavigationEvent.collectAsState(initial = false)
 
     LaunchedEffect(needRefresh) {
         if (needRefresh)
             viewModel.tryRefresh()
     }
 
-    LaunchedEffect(deleteSuccess) {
+    viewModel.goBackNavigationEvent.collectAsEffect { deleteSuccess ->
         if (deleteSuccess)
             goBackWithDeleteSuccess()
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
-import androidx.compose.material.Icon
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -35,7 +34,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.res.painterResource
 import androidx.core.net.toUri
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.model.Feeling
@@ -44,6 +42,9 @@ import com.strayalphaca.travel_diary.diary.model.FileType
 import com.strayalphaca.presentation.components.template.dialog.TwoButtonDialog
 import com.strayalphaca.presentation.components.template.error_view.ErrorView
 import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.presentation.screens.diary.component.ContentIconImage
+import com.strayalphaca.presentation.screens.diary.util.getFeelingIconId
+import com.strayalphaca.presentation.screens.diary.util.getWeatherIconId
 
 @Composable
 fun DiaryDetailContainer(
@@ -223,19 +224,18 @@ fun DiaryDetailScreen(
                         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
                             Text(text = stringResource(id = R.string.today_feeling), style = MaterialTheme.typography.body2)
                             Spacer(modifier = Modifier.width(6.dp))
-                            Icon(
-                                painter = painterResource(id = R.drawable.ic_feeling_angry),
-                                contentDescription = null,
-                                modifier = Modifier.size(36.dp)
+                            ContentIconImage(
+                                iconId = getFeelingIconId(state.diaryDetail.feeling),
+                                descriptionText = state.diaryDetail.feeling.name
                             )
                         }
                         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
                             Text(text = stringResource(id = R.string.weather), style = MaterialTheme.typography.body2)
                             Spacer(modifier = Modifier.width(6.dp))
-                            Icon(
-                                painter = painterResource(id = R.drawable.ic_weather_sunny),
-                                contentDescription = null,
-                                modifier = Modifier.size(36.dp)
+                            ContentIconImage(
+                                iconId = state.diaryDetail.weather?.let { getWeatherIconId(it) }
+                                    ?: R.drawable.ic_weather_sunny,
+                                descriptionText = state.diaryDetail.weather?.toString()
                             )
                         }
                     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -203,7 +203,7 @@ fun DiaryDetailScreen(
                                 style = MaterialTheme.typography.body2,
                                 modifier = Modifier
                                     .align(Alignment.CenterVertically)
-                                    .padding(end = 16.dp)
+                                    .padding(end = 10.dp)
                             )
 
                             Text(
@@ -223,7 +223,7 @@ fun DiaryDetailScreen(
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
                             Text(text = stringResource(id = R.string.today_feeling), style = MaterialTheme.typography.body2)
-                            Spacer(modifier = Modifier.width(6.dp))
+                            Spacer(modifier = Modifier.width(10.dp))
                             ContentIconImage(
                                 iconId = getFeelingIconId(state.diaryDetail.feeling),
                                 descriptionText = state.diaryDetail.feeling.name
@@ -231,7 +231,7 @@ fun DiaryDetailScreen(
                         }
                         Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
                             Text(text = stringResource(id = R.string.weather), style = MaterialTheme.typography.body2)
-                            Spacer(modifier = Modifier.width(6.dp))
+                            Spacer(modifier = Modifier.width(10.dp))
                             ContentIconImage(
                                 iconId = state.diaryDetail.weather?.let { getWeatherIconId(it) }
                                     ?: R.drawable.ic_weather_sunny,
@@ -254,9 +254,8 @@ fun DiaryDetailScreen(
                                 }
                             )
                         }
+                        Spacer(modifier = Modifier.height(24.dp))
                     }
-
-                    Spacer(modifier = Modifier.height(24.dp))
 
                     Text(
                         text = state.diaryDetail.content,

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.MaterialTheme
@@ -254,12 +255,20 @@ fun DiaryDetailScreen(
                                 }
                             )
                         }
-                        Spacer(modifier = Modifier.height(24.dp))
+                    } else {
+                        Divider(
+                            modifier = Modifier
+                                .fillMaxWidth(1f),
+                            thickness = 1.dp,
+                            color = MaterialTheme.colors.onSurface
+                        )
                     }
+
+                    Spacer(modifier = Modifier.height(24.dp))
 
                     Text(
                         text = state.diaryDetail.content,
-                        modifier = Modifier.padding(horizontal = 16.dp),
+                        modifier = Modifier.padding(horizontal = 8.dp),
                         style = MaterialTheme.typography.body2
                     )
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -316,7 +316,9 @@ class DiaryWriteViewModel @Inject constructor(
                     showInitLoading = false,
                     diaryDate = events.diaryDetail.date,
                     voiceFile = events.diaryDetail.voiceFile?.fileLink?.toUri(),
-                    imageFiles = events.diaryDetail.files.map { it.thumbnailLink?.toUri() ?: it.fileLink.toUri() }
+                    imageFiles = events.diaryDetail.files.map { it.thumbnailLink?.toUri() ?: it.fileLink.toUri() },
+                    cityId = events.diaryDetail.cityId,
+                    cityName = events.diaryDetail.cityName
                 )
             }
             DiaryWriteEvent.DiaryWriteLoading -> {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -52,6 +52,7 @@ import com.strayalphaca.presentation.screens.diary.util.getFeelingIconId
 import com.strayalphaca.presentation.screens.diary.util.getWeatherIconId
 import com.strayalphaca.presentation.utils.GetMediaActivityResultContract
 import com.strayalphaca.presentation.utils.checkUriIsVideo
+import com.strayalphaca.presentation.utils.collectAsEffect
 import com.strayalphaca.presentation.utils.isPhotoPickerAvailable
 
 @Composable
@@ -65,9 +66,8 @@ fun DiaryWriteContainer(
     val content by viewModel.writingContent.collectAsState()
     val state by viewModel.state.collectAsState()
     val musicProgress by viewModel.musicProgress.collectAsState()
-    val goBackNavigationEvent by viewModel.goBackNavigationEvent.collectAsState(initial = false)
 
-    LaunchedEffect(goBackNavigationEvent) {
+    viewModel.goBackNavigationEvent.collectAsEffect { goBackNavigationEvent ->
         if (goBackNavigationEvent)
             goBackWithModifySuccessResult()
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -236,12 +236,12 @@ fun DiaryWriteScreen(
 
                         ContentIconImage(
                             iconId = R.drawable.ic_gps,
-                            descriptionText = state.feeling.name,
+                            descriptionText = stringResource(id = R.string.select_location),
                             onClick = showLocationPickerDialog
                         )
-
-                        Spacer(modifier = Modifier.height(16.dp))
                     }
+
+                    Spacer(modifier = Modifier.height(16.dp))
 
                     Row(modifier = Modifier.fillMaxWidth()) {
                         Row(


### PR DESCRIPTION
- 일지 상세 조회 화면에서 감정/날씨 아이콘이 실제 데이터와 관련없이 항상 화남/맑음으로 고정되었던 부분 수정
- 일지 수정 화면에서 위치 데이터가 있음에서 위치 데이터를 누락하던 부분 수정
- 일지 조회/수정화면 UI 일부 수정(간격 수정, 구분선 추가)
- 로그인 여부에 따라 데모버젼/서버연결버전의 각기 다른 repository주입하도록 구현
- 도시에 따른 일지 목록 api의 path 수정
- viewModel의 sharedFlow를 기존 collectAsState로 전환해서 사용하던 방식에서 collectAsEffect (presentation 모듈의 util 참고)를 사용하도록 수정