### PR TITLE
Fix file

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
@@ -1,15 +1,28 @@
 package com.strayalphaca.travel_diary.di
 
 import com.strayalphaca.travel_diary.data.file.repository.FileRepositoryImpl
+import com.strayalphaca.travel_diary.data.file.repository.RemoteFileRepository
+import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import com.strayalphaca.travel_diary.domain.file.repository.FileRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
 
 @Module
 @InstallIn(SingletonComponent::class)
 object FileModule {
     @Provides
-    fun provideFileRepository() : FileRepository = FileRepositoryImpl()
+    fun provideFileRepository(
+        @BaseClient retrofit: Retrofit,
+        authRepository: AuthRepository
+    ) : FileRepository {
+        val hasToken = authRepository.getAccessToken() != null
+        return if (hasToken) {
+            RemoteFileRepository(retrofit)
+        } else {
+            FileRepositoryImpl()
+        }
+    }
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/api/FileApi.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/api/FileApi.kt
@@ -1,6 +1,6 @@
 package com.strayalphaca.travel_diary.data.file.api
 
-import com.strayalphaca.data.all.model.ListResponseData
+import com.strayalphaca.travel_diary.data.file.model.FileDto
 import okhttp3.RequestBody
 import retrofit2.Response
 import retrofit2.http.Multipart
@@ -10,5 +10,5 @@ import retrofit2.http.PartMap
 interface FileApi {
     @Multipart
     @POST("files")
-    suspend fun uploadFiles(@PartMap params : Map<String, RequestBody>) : Response<ListResponseData<String>>
+    suspend fun uploadFile(@PartMap params : Map<String, RequestBody>) : Response<FileDto>
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/api/FileApi.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/api/FileApi.kt
@@ -10,5 +10,5 @@ import retrofit2.http.PartMap
 interface FileApi {
     @Multipart
     @POST("files")
-    suspend fun uploadFile(@PartMap params : Map<String, RequestBody>) : Response<FileDto>
+    suspend fun uploadFile(@PartMap params : MutableMap<String, RequestBody>) : Response<FileDto>
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/model/FileDto.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/model/FileDto.kt
@@ -1,0 +1,8 @@
+package com.strayalphaca.travel_diary.data.file.model
+
+data class FileDto(
+    val id : String,
+    val type : String,
+    val originName : String,
+    val uploadedLink : String
+)

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/FileRepositoryImpl.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/FileRepositoryImpl.kt
@@ -4,7 +4,9 @@ import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.domain.file.model.FileInfo
 import com.strayalphaca.travel_diary.domain.file.repository.FileRepository
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class FileRepositoryImpl @Inject constructor() : FileRepository {
     override suspend fun uploadFile(fileInfo: FileInfo): BaseResponse<String> {
         return BaseResponse.Success<String>(data = "string")

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/RemoteFileRepository.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/RemoteFileRepository.kt
@@ -36,7 +36,7 @@ class RemoteFileRepository @Inject constructor(
                 throw IllegalArgumentException("cannot find file's type : $fileInfo")
             }
         }
-        val response = fileRetrofit.uploadFiles(partMap)
-        return responseToBaseResponseWithMapping(response) { it.data[0] }
+        val response = fileRetrofit.uploadFile(partMap)
+        return responseToBaseResponseWithMapping(response) { it.id }
     }
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/RemoteFileRepository.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/RemoteFileRepository.kt
@@ -11,7 +11,9 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import retrofit2.Retrofit
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class RemoteFileRepository @Inject constructor(
     retrofit : Retrofit
 ) : FileRepository {


### PR DESCRIPTION
- 로그인 여부에 따라 데모/서버 연동 fileRepository 구현체를 주입하도록 구현
- 파일 업로드 api가 다중 파일을 업로드하는 방식에서 단일 파일을 업로드 하는 방식으로 수정되었으므로 이를 반영
- @PartMap parameter의 타입을 Map에서 MutableMap으로 변경  
(Parameter type must not include a type variable or wildcard 수정 목적)