### PR TITLE
fix calendar

### DIFF
--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
@@ -17,7 +17,9 @@ class RemoteCalendarDataSource @Inject constructor(
 
     override suspend fun getDiaryData(year: Int, month: Int): BaseResponse<List<CalendarDiaryDto>> {
         val response = calendarRetrofit.getDiaryOfMonth(year, month)
-        return responseToBaseResponseWithMapping(response) {it.data}
+        return responseToBaseResponseWithMapping(response) { calendarDiaryDtoList ->
+            calendarDiaryDtoList.data.map { it.apply { dateStringFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" } }
+        }
     }
 
     override suspend fun checkWrittenOnToday(): BaseResponse<Boolean> {


### PR DESCRIPTION
달력 조회시 날짜 데이터 파싱 과정에서 발생한 문제로 인해 앱이 종료되던 문제 수정
- CalendarDiaryDto 데이터 클래스 내부에 dateStringFormat이라는 변수를 기본값과 같이 설정해 두었는데, retrofit을 사용해 서버로부터 받은 경우 설령 생성자로 주입받지 않고 클래스 내부에 기본값을 설정한 형태더라도 null로 값이 설정되는 부분을 몰랐었습니다.
- 그래서 해당 부분을 서버에서 데이터를 받은 후 apply를 사용하여 별도로 설정해주는 작업을 수행했습니다.