### PR TITLE
Fix diary

### DIFF
--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/api/DiaryApi.kt
@@ -1,7 +1,6 @@
 package com.strayalphaca.travel_diary.data.diary.api
 
 import com.strayalphaca.data.all.model.DiaryDto
-import com.strayalphaca.data.all.model.DiaryItemCityGroupDto
 import com.strayalphaca.data.all.model.DiaryItemDto
 import com.strayalphaca.data.all.model.ListResponseData
 import com.strayalphaca.travel_diary.data.diary.model.ModifyDiaryRequestBody
@@ -33,5 +32,5 @@ interface DiaryApi {
     suspend fun loadDiaryList(@Query("cityId") cityId : Int, @Query("page") page : Int, @Query("offset") offset : Int) : Response<ListResponseData<DiaryItemDto>>
 
     @GET("records/map")
-    suspend fun loadDiaryListByCityGroup(@Query("cityGroupId") cityGroupId : Int, @Query("page") page : Int, @Query("offset") offset : Int) : Response<ListResponseData<DiaryItemCityGroupDto>>
+    suspend fun loadDiaryListByCityGroup(@Query("groupId") cityGroupId : Int, @Query("page") page : Int, @Query("offset") offset : Int) : Response<ListResponseData<DiaryItemDto>>
 }

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryTestDataSource.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryTestDataSource.kt
@@ -1,5 +1,6 @@
 package com.strayalphaca.travel_diary.data.diary.data_source
 
+import com.strayalphaca.data.all.model.CityDto
 import com.strayalphaca.data.all.model.DiaryDto
 import com.strayalphaca.data.all.model.DiaryItemDto
 import com.strayalphaca.data.all.model.MediaFileInfoDto
@@ -27,7 +28,7 @@ class DiaryTestDataSource @Inject constructor() : DiaryDataSource {
         val result = mutableListOf<DiaryItemDto>()
 
         for (i in 0 until perPage) {
-            result.add(DiaryItemDto("${offset * perPage + i}", null, 1))
+            result.add(DiaryItemDto("${offset * perPage + i}", null, CityDto(id=cityId, name=""), provinceId = 1))
         }
 
         return result
@@ -43,7 +44,7 @@ class DiaryTestDataSource @Inject constructor() : DiaryDataSource {
         val result = mutableListOf<DiaryItemDto>()
 
         for (i in 0 until perPage) {
-            result.add(DiaryItemDto("${offset * perPage + i}", null, 1))
+            result.add(DiaryItemDto("${offset * perPage + i}", null, CityDto(id=1, name=""), provinceId = 1))
         }
 
         return result

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
@@ -7,7 +7,6 @@ import com.strayalphaca.travel_diary.data.diary.api.DiaryApi
 import com.strayalphaca.travel_diary.data.diary.model.ModifyDiaryRequestBody
 import com.strayalphaca.travel_diary.data.diary.model.UploadDiaryRequestBody
 import com.strayalphaca.travel_diary.data.diary.utils.diaryDtoToDiaryDetail
-import com.strayalphaca.travel_diary.data.diary.utils.diaryListCityGroupDtoToDiaryItem
 import com.strayalphaca.travel_diary.data.diary.utils.diaryListDtoToDiaryItem
 import com.strayalphaca.travel_diary.data.diary.utils.extractIdFromSignupResponse
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
@@ -51,7 +50,7 @@ class RemoteDiaryRepository @Inject constructor(
     ): List<DiaryItem> {
         val response = diaryRetrofit.loadDiaryListByCityGroup(cityGroupId = cityGroupId, page = perPage, offset = offset)
         if (response.isSuccessful && response.body() != null) {
-            return response.body()!!.data.map { diaryListCityGroupDtoToDiaryItem(it) }
+            return response.body()!!.data.map { diaryListDtoToDiaryItem(it) }
         } else {
             throw Exception("error occur when load diaryList : $cityGroupId, $perPage, $offset")
         }

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
@@ -1,7 +1,6 @@
 package com.strayalphaca.travel_diary.data.diary.utils
 
 import com.strayalphaca.data.all.model.DiaryDto
-import com.strayalphaca.data.all.model.DiaryItemCityGroupDto
 import com.strayalphaca.data.all.model.DiaryItemDto
 import com.strayalphaca.data.all.model.MediaFileInfoDto
 import com.strayalphaca.data.all.model.VoiceFileInDiaryDto
@@ -35,15 +34,7 @@ fun diaryListDtoToDiaryItem(diaryItemDto: DiaryItemDto) : DiaryItem {
     return DiaryItem(
         id = diaryItemDto.id,
         imageUrl = diaryItemDto.image?.shortLink ?: diaryItemDto.image?.uploadedLink,
-        cityName = City.findCity(diaryItemDto.cityId).name
-    )
-}
-
-fun diaryListCityGroupDtoToDiaryItem(diaryItemCityGroupDto: DiaryItemCityGroupDto) : DiaryItem {
-    return DiaryItem(
-        id = diaryItemCityGroupDto.id,
-        imageUrl = diaryItemCityGroupDto.image?.shortLink ?: diaryItemCityGroupDto.image?.uploadedLink,
-        cityName = City.findCity(diaryItemCityGroupDto.provinceId).name
+        cityName = City.findCity(diaryItemDto.city.id).name
     )
 }
 

--- a/data/src/main/java/com/strayalphaca/data/all/model/ResponseData.kt
+++ b/data/src/main/java/com/strayalphaca/data/all/model/ResponseData.kt
@@ -34,13 +34,13 @@ data class VoiceFileInDiaryDto(
 data class DiaryItemDto(
     val id : String,
     val image : ImageDto?,
-    val cityId : Int
+    val city : CityDto,
+    val provinceId : Int
 )
 
-data class DiaryItemCityGroupDto(
-    val id : String,
-    val image : ImageDto?,
-    val provinceId : Int
+data class CityDto(
+    val id : Int,
+    val name : String
 )
 
 data class ImageDto(

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
@@ -28,7 +28,7 @@ import com.strayalphaca.travel_diary.map.model.City
 @Composable
 fun CityPickerDialog(
     onDismissRequest : () -> Unit = {},
-    onLocationSelect : (locationId : Int) -> Unit,
+    onLocationSelect : (locationId : Int?) -> Unit,
     cityGroupId : Int,
     currentSelectedLocationId : Int ?= null
 ) {
@@ -57,7 +57,11 @@ fun CityPickerDialog(
                                 color = if (selectedLocation == city.id) MaterialTheme.colors.onSurface else MaterialTheme.colors.surface
                             )
                             .clickable {
-                                selectedLocation = city.id
+                                selectedLocation = if (selectedLocation == city.id) {
+                                    null
+                                } else {
+                                    city.id
+                                }
                             }
                             .padding(vertical = 8.dp)
                         ,
@@ -84,10 +88,9 @@ fun CityPickerDialog(
 
                 TextButton(
                     onClick = {
-                        onLocationSelect(selectedLocation ?: -1)
+                        onLocationSelect(selectedLocation)
                         onDismissRequest()
-                    },
-                    enabled = selectedLocation != null
+                    }
                 ) {
                     Text(text = stringResource(id = R.string.confirm), color = MaterialTheme.colors.onSurface)
                 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/MediaFileInDiary.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/MediaFileInDiary.kt
@@ -1,0 +1,59 @@
+package com.strayalphaca.presentation.screens.diary.model
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.strayalphaca.presentation.screens.diary.util.fileTypeTransfer
+import com.strayalphaca.travel_diary.diary.model.File
+import com.strayalphaca.travel_diary.domain.file.model.FileType
+
+sealed class MediaFileInDiary(
+    val fileType: FileType,
+    val uri: Uri,
+) {
+    class UploadedFile(
+        val id: String,
+        fileUri: Uri,
+        fileType: FileType,
+        val thumbnailUri: Uri? = null
+    ) : MediaFileInDiary(fileType, fileUri) {
+        companion object {
+            fun createFromFile(file: File): UploadedFile {
+                return UploadedFile(
+                    id = file.id,
+                    fileUri = file.fileLink.toUri(),
+                    fileType = fileTypeTransfer(file.type),
+                    thumbnailUri = file.thumbnailLink?.toUri()
+                )
+            }
+        }
+    }
+
+    class LocalFile(
+        localUri: Uri,
+        fileType: FileType
+    ) : MediaFileInDiary(fileType, localUri)
+
+    fun checkUri(targetUri: Uri): Boolean {
+        return when (this) {
+            is UploadedFile -> {
+                targetUri == uri || targetUri == thumbnailUri
+            }
+
+            is LocalFile -> {
+                targetUri == uri
+            }
+        }
+    }
+
+    fun getThumbnailUriOrFileUri(): Uri {
+        return when (this) {
+            is UploadedFile -> {
+                thumbnailUri ?: uri
+            }
+
+            is LocalFile -> {
+                uri
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/util/FileTypeTransfer.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/util/FileTypeTransfer.kt
@@ -1,0 +1,20 @@
+package com.strayalphaca.presentation.screens.diary.util
+
+import com.strayalphaca.travel_diary.diary.model.FileType
+
+private typealias FileTypeInFile = com.strayalphaca.travel_diary.domain.file.model.FileType
+private typealias FileTypeInDiary = FileType
+
+fun fileTypeTransfer(fileType : FileTypeInDiary) : FileTypeInFile {
+    return when (fileType) {
+        FileTypeInDiary.IMAGE -> {
+            FileTypeInFile.Image
+        }
+        FileTypeInDiary.VIDEO -> {
+            FileTypeInFile.Video
+        }
+        FileTypeInDiary.VOICE -> {
+            FileTypeInFile.Voice
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -36,7 +36,6 @@ import com.strayalphaca.presentation.ui.theme.Gray2
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -51,9 +50,9 @@ import com.strayalphaca.presentation.screens.diary.model.CurrentShowSelectView
 import com.strayalphaca.presentation.screens.diary.util.getFeelingIconId
 import com.strayalphaca.presentation.screens.diary.util.getWeatherIconId
 import com.strayalphaca.presentation.utils.GetMediaActivityResultContract
-import com.strayalphaca.presentation.utils.checkUriIsVideo
 import com.strayalphaca.presentation.utils.collectAsEffect
 import com.strayalphaca.presentation.utils.isPhotoPickerAvailable
+import com.strayalphaca.travel_diary.domain.file.model.FileType
 
 @Composable
 fun DiaryWriteContainer(
@@ -126,8 +125,6 @@ fun DiaryWriteScreen(
 ) {
     val scrollState = rememberScrollState()
     val lifecycleOwner = LocalLifecycleOwner.current
-    val context = LocalContext.current
-
 
     val photoPickerLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickMultipleVisualMedia(3)
@@ -314,9 +311,9 @@ fun DiaryWriteScreen(
                     Spacer(modifier = Modifier.height(24.dp))
 
                     if (state.imageFiles.isNotEmpty()) {
-                        HorizontalPager(pageCount = state.imageFiles.size) {
-                            val isVideo = checkUriIsVideo(state.imageFiles[it], context)
-                            PolaroidView(fileUri = state.imageFiles[it], thumbnailUri = state.imageFiles[it], isVideo = isVideo, onClick = goToVideo, onDeleteClick = deleteImageFile)
+                        HorizontalPager(pageCount = state.imageFiles.size) { index ->
+                            val isVideo = state.imageFiles[index].fileType == FileType.Video
+                            PolaroidView(fileUri = state.imageFiles[index].uri, thumbnailUri = state.imageFiles[index].getThumbnailUriOrFileUri(), isVideo = isVideo, onClick = goToVideo, onDeleteClick = deleteImageFile)
                         }
                         Spacer(modifier = Modifier.height(24.dp))
                     }
@@ -347,9 +344,9 @@ fun DiaryWriteScreen(
 
                     Spacer(modifier = Modifier.height(24.dp))
 
-                    state.voiceFile?.let { uri ->
+                    state.voiceFile?.let { mediaFileInDiary ->
                         SoundView(
-                            file = uri,
+                            file = mediaFileInDiary.uri,
                             playing = state.musicPlaying,
                             play = playMusic,
                             pause = pauseMusic,

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/paging/DiaryListSimplePaging.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/paging/DiaryListSimplePaging.kt
@@ -17,7 +17,7 @@ class DiaryListSimplePaging(
     private val perPage: Int,
     private val targetId: Int,
     private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.IO),
-    private val initKey : Int = 0,
+    private val initKey : Int = 1,
 ) : SimplePaging<DiaryItem> {
 
     private val data : MutableStateFlow<List<DiaryItem>> = MutableStateFlow(emptyList())
@@ -34,7 +34,7 @@ class DiaryListSimplePaging(
 
         requestJob = coroutineScope.launch {
             try {
-                val response = getDiaryList(targetId, perPage * firstLoadingPageRatio, currentKey)
+                val response = getDiaryList(targetId, perPage * firstLoadingPageRatio, initKey)
                 if (response.size < perPage * firstLoadingPageRatio) {
                     state.value = SimplePagingState.LAST
                 } else {

--- a/presentation/src/main/java/com/strayalphaca/presentation/utils/UriHandler.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/utils/UriHandler.kt
@@ -13,7 +13,7 @@ import javax.inject.Singleton
 
 @Singleton
 class UriHandler @Inject constructor(
-    @ApplicationContext private val  context : Context
+    @ApplicationContext private val context : Context
 ) {
     fun uriToFile(uri : Uri) : FileInfo {
         val path = uriToFilePath(uri)
@@ -36,7 +36,7 @@ class UriHandler @Inject constructor(
         return path ?: throw IllegalArgumentException("file path from uri does not exist : $uri")
     }
 
-    private fun getFileType(uri: Uri): FileType {
+    fun getFileType(uri: Uri): FileType {
         val mimeType = context.contentResolver.getType(uri) ?: return FileType.Unknown
         return when {
             mimeType.contains("audio") -> {


### PR DESCRIPTION
일지 수정 과정에서 발생하는 아래 문제점 수정
- 이미 사진/동영상이 존재하는 일지에서 기존에 등록한 이미지/동영상이 존재할 때 수정하기를 누를 경우, uri을 기기에서 찾지 못해 에러가 발생
  - 이에 기존 Uri만 사용했던 구조에서 일지 내 사용되는 파일을 의미하는 MediaFileInDiary sealed 클래스 생성
    - 이미 서버에 등록된 이미지/동영상의 경우 UploadedFile
    - 기기에서 추가된  이미지/동영상의 경우 LocalFile로 선언
- 일지 목록 조회 api에서 cityId로 접근했을 때와 groupId로 접근했을 때의 Dto 형식을 통일했으므로, 해당 내역을 반영
- 일지 목록 조회 api에서 첫 페이지를 1로 설정했으므로, 해당 내용을 반영하여 초기 페이지 번호를 1로 수정
- 일지 목록에서 조회할 지역 선택하는 다이얼로그에서 이미 선택된 지역을 다시 클릭하여 해제할 수 있도록 수정