### PR TITLE
Fix diary

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
@@ -1,12 +1,16 @@
 package com.strayalphaca.travel_diary.di
 
+import android.content.Context
+import com.strayalphaca.presentation.screens.diary.model.FileResizeHandlerImpl
 import com.strayalphaca.travel_diary.data.file.repository.FileRepositoryImpl
 import com.strayalphaca.travel_diary.data.file.repository.RemoteFileRepository
 import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
+import com.strayalphaca.travel_diary.domain.file.model.FileResizeHandler
 import com.strayalphaca.travel_diary.domain.file.repository.FileRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 
@@ -24,5 +28,12 @@ object FileModule {
         } else {
             FileRepositoryImpl()
         }
+    }
+
+    @Provides
+    fun provideFileResizeHandler(
+        @ApplicationContext context: Context
+    ) : FileResizeHandler {
+        return FileResizeHandlerImpl(context)
     }
 }

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/repository_impl/RemoteDiaryRepository.kt
@@ -35,7 +35,7 @@ class RemoteDiaryRepository @Inject constructor(
     }
 
     override suspend fun getDiaryList(cityId: Int, perPage: Int, offset: Int): List<DiaryItem> {
-        val response = diaryRetrofit.loadDiaryList(cityId = cityId, page = perPage, offset = offset)
+        val response = diaryRetrofit.loadDiaryList(cityId = cityId, page = offset, offset = perPage)
         if (response.isSuccessful && response.body() != null) {
             return response.body()!!.data.map { diaryListDtoToDiaryItem(it) }
         } else {
@@ -48,7 +48,7 @@ class RemoteDiaryRepository @Inject constructor(
         perPage: Int,
         offset: Int
     ): List<DiaryItem> {
-        val response = diaryRetrofit.loadDiaryListByCityGroup(cityGroupId = cityGroupId, page = perPage, offset = offset)
+        val response = diaryRetrofit.loadDiaryListByCityGroup(cityGroupId = cityGroupId, page = offset, offset = perPage)
         if (response.isSuccessful && response.body() != null) {
             return response.body()!!.data.map { diaryListDtoToDiaryItem(it) }
         } else {

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
@@ -65,7 +65,7 @@ internal fun weatherStringToEnum(weather : String?) : Weather {
 
 fun mediaFileInfoDtoToFile(fileDto: MediaFileInfoDto) : File {
     return File(
-        id = fileDto.originName,
+        id = fileDto.id,
         fileLink = fileDto.shortLink ?: fileDto.uploadedLink,
         type = when (fileDto.type) {
             "video", "VIDEO" -> FileType.VIDEO

--- a/data/src/main/java/com/strayalphaca/data/all/model/ResponseData.kt
+++ b/data/src/main/java/com/strayalphaca/data/all/model/ResponseData.kt
@@ -1,6 +1,7 @@
 package com.strayalphaca.data.all.model
 
 data class MediaFileInfoDto(
+    val id : String = "",
     val originName : String,
     val type : String = "",
     val uploadedLink : String = "",

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
@@ -1,0 +1,69 @@
+package com.strayalphaca.presentation.screens.diary.model
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Environment
+import com.strayalphaca.travel_diary.domain.file.model.FileResizeHandler
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import kotlin.math.sqrt
+
+class FileResizeHandlerImpl @Inject constructor(
+    val context : Context
+) : FileResizeHandler {
+    override fun resizeImageFile(file: File, maxByteSize: Int): File {
+        if (!file.exists() || !file.isFile) {
+            throw IllegalArgumentException("Input file does not exist or is not a regular file.")
+        }
+
+        try {
+            val originalSize = file.length()
+            if (originalSize <= maxByteSize) {
+                return file
+            }
+
+            val options = BitmapFactory.Options()
+            options.inJustDecodeBounds = true
+            BitmapFactory.decodeFile(file.absolutePath, options)
+
+            options.inSampleSize = calculateInSampleSize(options, maxByteSize)
+
+            options.inJustDecodeBounds = false
+            val originalBitmap = BitmapFactory.decodeFile(file.absolutePath, options)
+
+            val scale = sqrt(maxByteSize.toDouble() / originalSize)
+            val newWidth = (originalBitmap.width * scale).toInt()
+            val newHeight = (originalBitmap.height * scale).toInt()
+
+            val resizedBitmap = Bitmap.createScaledBitmap(originalBitmap, newWidth, newHeight, true)
+
+            val outputDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
+            val resizedFile = File(outputDir, "resized_${file.name}")
+
+            val outputStream = FileOutputStream(resizedFile)
+            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outputStream)
+            outputStream.close()
+
+            return resizedFile
+        } catch (e: Exception) {
+            throw RuntimeException("Error while resizing image: ${e.message}", e)
+        }
+    }
+
+    private fun calculateInSampleSize(options : BitmapFactory.Options, maxByteSize : Int) : Int {
+        val originalHeight = options.outHeight
+        val originalWidth = options.outWidth
+        var inSampleSize = 1
+
+        val totalPixels = originalHeight * originalWidth
+        val totalPixelsCap = maxByteSize / 2
+
+        while (totalPixels / (inSampleSize * inSampleSize) > totalPixelsCap) {
+            inSampleSize *= 2
+        }
+
+        return inSampleSize
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
@@ -43,7 +43,7 @@ class FileResizeHandlerImpl @Inject constructor(
             val resizedFile = File(outputDir, "resized_${file.name}")
 
             val outputStream = FileOutputStream(resizedFile)
-            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 85, outputStream)
+            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
             outputStream.close()
 
             return resizedFile

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -238,10 +238,16 @@ class DiaryWriteViewModel @Inject constructor(
                 )
             }
 
-            if (response is BaseResponse.Success) {
-                events.send(DiaryWriteEvent.DiaryWriteSuccess(response.data))
-            } else {
-                events.send(DiaryWriteEvent.DiaryWriteFail)
+            when (response) {
+                is BaseResponse.Success -> { // 새로 작성한 경우, response에 새로 작성된 일지의 id가 같이 리턴됨
+                    events.send(DiaryWriteEvent.DiaryWriteSuccess(response.data))
+                }
+                is BaseResponse.EmptySuccess -> { // 기존 일지를 수정한 경우, 별도의 데이터가 같이 전달되지 않음
+                    events.send(DiaryWriteEvent.DiaryWriteSuccess(diaryId!!))
+                }
+                else -> {
+                    events.send(DiaryWriteEvent.DiaryWriteFail)
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -311,7 +311,7 @@ class DiaryWriteViewModel @Inject constructor(
             val diaryInCalendar = DiaryInCalendar(
                 id = id,
                 date = state.value.diaryDate,
-                thumbnailUrl = state.value.imageFiles.getOrNull(0)?.toString()
+                thumbnailUrl = state.value.imageFiles.getOrNull(0)?.uri.toString()
             )
             if (isModify) {
                 useCaseHandleCachedCalendarDiary.update(diaryInCalendar)

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -11,6 +11,7 @@ import com.strayalphaca.presentation.screens.diary.model.MediaFileInDiary
 import com.strayalphaca.presentation.screens.diary.model.MusicPlayer
 import com.strayalphaca.presentation.screens.diary.util.getInstanceFromDateString
 import com.strayalphaca.presentation.utils.UriHandler
+import com.strayalphaca.presentation.utils.mapIf
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.model.DiaryModifyData
 import com.strayalphaca.travel_diary.diary.model.DiaryWriteData
@@ -21,6 +22,7 @@ import com.strayalphaca.travel_diary.diary.use_case.UseCaseModifyDiary
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseUploadDiary
 import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
 import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseHandleCachedCalendarDiary
+import com.strayalphaca.travel_diary.domain.file.model.FileResizeHandler
 import com.strayalphaca.travel_diary.domain.file.model.FileType
 import com.strayalphaca.travel_diary.domain.file.usecase.UseCaseUploadFiles
 import com.strayalphaca.travel_diary.map.model.City
@@ -44,7 +46,8 @@ class DiaryWriteViewModel @Inject constructor(
     private val useCaseUploadDiary: UseCaseUploadDiary,
     private val useCaseModifyDiary: UseCaseModifyDiary,
     private val musicPlayer: MusicPlayer,
-    private val uriHandler: UriHandler
+    private val uriHandler: UriHandler,
+    private val fileResizeHandler: FileResizeHandler
 ) : ViewModel() {
     private val events = Channel<DiaryWriteEvent>()
     val state: StateFlow<DiaryWriteState> = events.receiveAsFlow()
@@ -250,6 +253,10 @@ class DiaryWriteViewModel @Inject constructor(
 
         val localFileList = fileList.filterIsInstance<MediaFileInDiary.LocalFile>()
             .map { uriHandler.uriToFile(it.uri) }
+            .mapIf({it.fileType == FileType.Image}) {
+                val resizedFile = fileResizeHandler.resizeImageFile(it.file, 1024 * 1024)
+                it.copy(file = resizedFile)
+            }
 
         val response = useCaseUploadFiles(localFileList)
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/DiaryListViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/DiaryListViewModel.kt
@@ -2,6 +2,7 @@ package com.strayalphaca.presentation.screens.diary_list
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.strayalphaca.presentation.screens.diary_list.model.SearchTargetType
 import com.strayalphaca.presentation.screens.diary_list.paging.DiaryListSimplePaging
 import com.strayalphaca.travel_diary.diary.model.DiaryItemUpdate
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryList
@@ -68,7 +69,8 @@ class DiaryListViewModel @Inject constructor(
             diaryListSimplePaging = DiaryListSimplePaging(
                 getDiaryList = useCaseGetDiaryList::getByCityGroupId,
                 perPage = 10,
-                targetId = cityGroupId
+                targetId = cityGroupId,
+                targetType = SearchTargetType.GROUP
             )
             viewModelScope.launch {
                 diaryListSimplePaging.refresh()
@@ -80,7 +82,8 @@ class DiaryListViewModel @Inject constructor(
             diaryListSimplePaging = DiaryListSimplePaging(
                 getDiaryList = useCaseGetDiaryList::invoke,
                 perPage = 10,
-                targetId = cityId
+                targetId = cityId,
+                targetType = SearchTargetType.CITY
             )
             viewModelScope.launch {
                 diaryListSimplePaging.refresh()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/model/SearchTargetType.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/model/SearchTargetType.kt
@@ -1,0 +1,5 @@
+package com.strayalphaca.presentation.screens.diary_list.model
+
+enum class SearchTargetType {
+    CITY, GROUP
+}


### PR DESCRIPTION
일지 작성/수정 과정에서 아래 부분을 추가함.
- 이미지 파일의 크기가 일정 크기 이상일 때 크기를 resize하는 FileResizeHandler의 구현체 설정 및 해당 클래스 주입 코드 작성  

일지 작성/수정 과정에서 아래 부분을 수정함.
- 일지 수정 성공 후 이전 화면으로 돌아가지 않는 부분을 수정
- 이미지 수정 후 캐시된 일지 데이터를 수정된 일지 데이터에 맞게 반영하는 과정에서 thumbnailUri에 Uri.toString()이 아닌, MediaFileInDiary.toString()이 들어가 잘못된 값으로 설정되었던 문제 수정

일지 목록 관련 아래 부분을 수정함.
- 일지 목록 api의 offset, page 쿼리 파라미터를 서로 교체
- 일지 목록 데이터를 보관하는 DiarySimplePaging클래스에 해당 리스트 데이터가 cityId로 불러온 데이터인지, groupId로 불러온 데이터인지를  파악하기 위한 변수 추가
  - cityId로 불러왔을때와 groupId로 불러왔을 때, 수정된 일지의 위치 관련하여 현재 지역인지를 판단하는 부분이 달라지므로 이 변수가 필요함
- DairySimplePaging과 관련된 테스트코드 갱신