### PR TITLE
Fix calendar

### DIFF
--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/RemoteCalendarDataSource.kt
@@ -30,7 +30,7 @@ class RemoteCalendarDataSource @Inject constructor(
             response.isSuccessful && response.code() == 200 -> {
                 BaseResponse.Success(data = true)
             }
-            response.isSuccessful && response.code() != 200 -> {
+            response.code() == 409 -> {
                 BaseResponse.Success(data = false)
             }
             else -> {

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_store/CalendarDataStoreImpl.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_store/CalendarDataStoreImpl.kt
@@ -32,7 +32,7 @@ class CalendarDataStoreImpl @Inject constructor() : CalendarDataStore {
         val diaryList : List<DiaryInCalendar> = monthCalendarData.value.diaryList
         val target : DiaryInCalendar = diaryList.find { it.id == data.id } ?: return
         val dataList : List<DiaryInCalendar> = diaryList.map {
-            if (it.id == target.id) target else it
+            if (it.id == target.id) data else it
         }.sortedBy { it.day }
         monthCalendarData.value = monthCalendarData.value.copy(diaryList = dataList)
     }


### PR DESCRIPTION
- 오늘 날짜에 일지를 작성했는지 여부를 판단하는 api의 응답을 처리하는 과정에서 아래 부분 수정
  - Response를 오늘 일지 작성을 했음을 나타내는 BaseResponse로 매핑하는데 수행되던 when의 조건을 변경

- 캐시된 달력 데이터에 일지 수정 내역을 반영하는 과정에서 collection의 map함수 내 리턴값을 잘못 지정한 부분 수정 (변경되기 전 값을 그대로 리턴했었음)