### PR TITLE
Fix UI

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/atom/text_button/TextButton.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/atom/text_button/TextButton.kt
@@ -2,11 +2,15 @@ package com.strayalphaca.presentation.components.atom.text_button
 
 import android.content.res.Configuration
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -24,11 +28,17 @@ fun TextButton(
     text : String,
     state : TextButtonState = TextButtonState.ACTIVE,
     onClick : () -> Unit = {},
-    textStyle : TextStyle = MaterialTheme.typography.button
+    textStyle : TextStyle = MaterialTheme.typography.button,
+    interactionSource : MutableInteractionSource = remember { MutableInteractionSource() }
 ) {
+    val isPressed by interactionSource.collectIsPressedAsState()
     Box(
         modifier
-            .clickable(enabled = state != TextButtonState.INACTIVE) {
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+                enabled = state != TextButtonState.INACTIVE,
+            ) {
                 onClick()
             },
     ) {
@@ -36,7 +46,11 @@ fun TextButton(
             text = text,
             modifier = Modifier.padding(vertical = 12.dp),
             style = textStyle,
-            color = if (state == TextButtonState.ACTIVE) MaterialTheme.colors.onBackground else Gray4
+            color = if (state == TextButtonState.ACTIVE && !isPressed) {
+                MaterialTheme.colors.onBackground
+            } else {
+                Gray4
+            }
         )
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
@@ -14,7 +14,9 @@ import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
 import com.strayalphaca.presentation.ui.theme.Tape
 
 @Composable
@@ -44,7 +46,14 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
                         .fillMaxWidth()
                         .aspectRatio(0.8f)
                         .background(Tape)
-                )
+                ) {
+                    AsyncImage(
+                        model = thumbnailUrl,
+                        contentDescription = "thumbnail_image",
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
             }
 
             Spacer(modifier = Modifier.height(10.dp))

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryItemView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryItemView.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.strayalphaca.presentation.ui.theme.Tape
@@ -53,7 +54,8 @@ fun DiaryItemView(
                     AsyncImage(
                         modifier = Modifier.fillMaxSize(),
                         model = imageUrl,
-                        contentDescription = "image"
+                        contentDescription = "image",
+                        contentScale = ContentScale.Crop
                     )
                 }
             }


### PR DESCRIPTION
- map화면에서 일지의 이미지가 보여지지 않던 문제 수정
- 일지 목록 화면에서 일지 미이지의 scaletype을 기본값에서 centercrop으로 수정
- 텍스트 버튼 관련해서 기본 ripple 이펙트 제거 및 press시 글자 색상이 옅어지도록 수정