### PR TITLE
Fix diary

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ datastore = "1.0.0"
 paging = "3.1.1"
 paging_compose = "3.2.0"
 coroutine = "1.7.3"
+exifinterface = "1.3.6"
 
 [libraries]
 android-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -79,6 +80,8 @@ paging3Compose = { group = "androidx.paging", name = "paging-compose", version.r
 
 coroutine = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutine"}
 coroutine_test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutine" }
+
+exifinterface = { group = "androidx.exifinterface", name = "exifinterface", version.ref = "exifinterface" }
 
 [bundles]
 okhttp3 = ["okhttp3-okhttp", "okhttp3-logging-interceptor"]

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -95,6 +95,9 @@ dependencies {
 
     // coroutine test
     testImplementation libs.coroutine.test
+
+    // exif interface
+    implementation libs.exifinterface
 }
 
 kapt {

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/EmptyPolaroidView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/EmptyPolaroidView.kt
@@ -1,0 +1,141 @@
+package com.strayalphaca.presentation.components.block
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.strayalphaca.presentation.R
+import com.strayalphaca.presentation.ui.theme.Gray4
+import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
+
+@Composable
+fun EmptyPolaroidView(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    Box(modifier = modifier.fillMaxWidth()) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(4.dp)
+                .dashedBorder(
+                    color = Gray4,
+                    strokeWidth = 1.dp,
+                )
+        ) {
+            Column(
+                modifier = Modifier.padding(12.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.dp)
+                        .clickable { onClick() }
+                        .dashedBorder(
+                            color = Gray4,
+                            strokeWidth = 1.dp,
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Image(
+                            modifier = Modifier.size(48.dp),
+                            painter = painterResource(id = R.drawable.ic_image),
+                            contentDescription = "add image",
+                            colorFilter = ColorFilter.tint(Gray4)
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(id = R.string.add_image),
+                            style = MaterialTheme.typography.caption,
+                            color = Gray4,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(text = "", style = MaterialTheme.typography.caption)
+            }
+
+        }
+    }
+}
+
+@Composable
+@Preview(
+    showBackground = true,
+    widthDp = 360,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "dark"
+)
+@Preview(showBackground = true, widthDp = 360)
+fun EmptyPolaroidViewPreview() {
+    TravelDiaryTheme {
+        Surface(modifier = Modifier.padding(16.dp)) {
+            EmptyPolaroidView()
+        }
+    }
+}
+
+fun Modifier.dashedBorder(
+    color: Color = Gray4,
+    shape: Shape = RectangleShape,
+    strokeWidth: Dp = 1.dp,
+    dashWidth: Dp = 12.dp,
+    gapWidth: Dp = 12.dp,
+    cap: StrokeCap = StrokeCap.Round
+) = this.drawWithContent {
+    val outline = shape.createOutline(size, layoutDirection, this)
+
+    val path = Path()
+    path.addOutline(outline)
+
+    val stroke = Stroke(
+        cap = cap,
+        width = strokeWidth.toPx(),
+        pathEffect = PathEffect.dashPathEffect(
+            intervals = floatArrayOf(dashWidth.toPx(), gapWidth.toPx()),
+            phase = 0f
+        )
+    )
+
+    this.drawContent()
+
+    drawPath(
+        path = path,
+        style = stroke,
+        color = color
+    )
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/EmptySoundView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/EmptySoundView.kt
@@ -1,0 +1,88 @@
+package com.strayalphaca.presentation.components.block
+
+import android.content.res.Configuration
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.strayalphaca.presentation.R
+import com.strayalphaca.presentation.ui.theme.Gray4
+import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
+
+@Composable
+fun EmptySoundView(
+    modifier : Modifier = Modifier,
+    onClick : () -> Unit = {}
+) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        Surface(modifier = modifier
+            .fillMaxWidth()
+            .padding(4.dp)
+            .clickable {
+                onClick()
+            }
+            .dashedBorder(
+                color = Gray4,
+                strokeWidth = 1.dp
+            )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(30.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Image(
+                    modifier = Modifier.size(24.dp),
+                    painter = painterResource(id = R.drawable.ic_music),
+                    contentDescription = "add audio",
+                    colorFilter = ColorFilter.tint(Gray4)
+                )
+
+                Spacer(modifier = Modifier.width(8.dp))
+
+                Text(
+                    text = stringResource(id = R.string.add_audio),
+                    style = MaterialTheme.typography.caption,
+                    color = Gray4,
+                    textAlign = TextAlign.Center
+                )
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(
+    showBackground = true,
+    widthDp = 360,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "dark"
+)
+@Preview(showBackground = true, widthDp = 360)
+fun EmptySoundViewPreview() {
+    TravelDiaryTheme {
+        Surface(modifier = Modifier.padding(16.dp)) {
+            EmptySoundView()
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -252,7 +252,9 @@ fun DiaryDetailScreen(
                                 onClick = { uri ->
                                     if (state.deleteLoading) return@PolaroidView
                                     goToVideo(uri)
-                                }
+                                },
+                                dateString = state.diaryDetail.date.toString(),
+                                positionString = "${it + 1}/${state.diaryDetail.files.size}"
                             )
                         }
                     } else {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/FileResizeHandlerImpl.kt
@@ -3,7 +3,9 @@ package com.strayalphaca.presentation.screens.diary.model
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Matrix
 import android.os.Environment
+import androidx.exifinterface.media.ExifInterface
 import com.strayalphaca.travel_diary.domain.file.model.FileResizeHandler
 import java.io.File
 import java.io.FileOutputStream
@@ -24,6 +26,21 @@ class FileResizeHandlerImpl @Inject constructor(
                 return file
             }
 
+            val exif = ExifInterface(file.path)
+            val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+            val matrix = Matrix()
+            when (orientation) {
+                ExifInterface.ORIENTATION_ROTATE_90 -> {
+                    matrix.postRotate(90f)
+                }
+                ExifInterface.ORIENTATION_ROTATE_180 -> {
+                    matrix.postRotate(180f)
+                }
+                ExifInterface.ORIENTATION_ROTATE_270 -> {
+                    matrix.postRotate(270f)
+                }
+            }
+
             val options = BitmapFactory.Options()
             options.inJustDecodeBounds = true
             BitmapFactory.decodeFile(file.absolutePath, options)
@@ -37,13 +54,18 @@ class FileResizeHandlerImpl @Inject constructor(
             val newWidth = (originalBitmap.width * scale).toInt()
             val newHeight = (originalBitmap.height * scale).toInt()
 
-            val resizedBitmap = Bitmap.createScaledBitmap(originalBitmap, newWidth, newHeight, true)
+            val outputBitmap = run {
+                val resizedBitmap = Bitmap.createScaledBitmap(originalBitmap, newWidth, newHeight, true)
+                Bitmap.createBitmap(resizedBitmap, 0, 0, resizedBitmap.width, resizedBitmap.height, matrix, true).also {
+                    resizedBitmap.recycle()
+                }
+            }
 
             val outputDir = context.getExternalFilesDir(Environment.DIRECTORY_PICTURES)
             val resizedFile = File(outputDir, "resized_${file.name}")
 
             val outputStream = FileOutputStream(resizedFile)
-            resizedBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+            outputBitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
             outputStream.close()
 
             return resizedFile
@@ -52,13 +74,14 @@ class FileResizeHandlerImpl @Inject constructor(
         }
     }
 
+    // 이미지를 로드할 때 [maxByte, maxByte*4) 로 이미지가 로드되도록 inSampleSize를 리턴
     private fun calculateInSampleSize(options : BitmapFactory.Options, maxByteSize : Int) : Int {
         val originalHeight = options.outHeight
         val originalWidth = options.outWidth
         var inSampleSize = 1
 
         val totalPixels = originalHeight * originalWidth
-        val totalPixelsCap = maxByteSize / 2
+        val totalPixelsCap = maxByteSize * 4
 
         while (totalPixels / (inSampleSize * inSampleSize) > totalPixelsCap) {
             inSampleSize *= 2

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -119,7 +119,7 @@ class DiaryWriteViewModel @Inject constructor(
 
     fun inputImageFile(file : List<Uri>) {
         viewModelScope.launch {
-            events.send(DiaryWriteEvent.ChangeImageList(file))
+            events.send(DiaryWriteEvent.AddImageList(file))
         }
     }
 
@@ -366,8 +366,10 @@ class DiaryWriteViewModel @Inject constructor(
             DiaryWriteEvent.RemoveVoiceFile -> {
                 state.copy(voiceFile = null)
             }
-            is DiaryWriteEvent.ChangeImageList -> {
-                state.copy(imageFiles = events.file.map { MediaFileInDiary.LocalFile(localUri = it, fileType = uriHandler.getFileType(it)) })
+            is DiaryWriteEvent.AddImageList -> {
+                val newImages = events.file.map { MediaFileInDiary.LocalFile(localUri = it, fileType = uriHandler.getFileType(it)) }
+                val images = (state.imageFiles + newImages)
+                state.copy(imageFiles = images.subList(0, 3.coerceAtMost(images.size)))
             }
             is DiaryWriteEvent.DeleteImage -> {
                 val imageFiles = state.imageFiles.filter { !it.checkUri(events.file) }
@@ -426,7 +428,7 @@ sealed class DiaryWriteEvent {
     class DiaryWriteSuccess(val id : String) : DiaryWriteEvent()
     class AddVoiceFile(val file : Uri) : DiaryWriteEvent()
     object RemoveVoiceFile : DiaryWriteEvent()
-    class ChangeImageList(val file : List<Uri>) : DiaryWriteEvent()
+    class AddImageList(val file : List<Uri>) : DiaryWriteEvent()
     class DeleteImage(val file : Uri) : DiaryWriteEvent()
     class SetFeeling(val feeling: Feeling) : DiaryWriteEvent()
     class SetWeather(val weather: Weather) : DiaryWriteEvent()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -327,7 +327,9 @@ fun DiaryWriteScreen(
                                 thumbnailUri = state.imageFiles[index].getThumbnailUriOrFileUri(),
                                 isVideo = isVideo,
                                 onClick = goToVideo,
-                                onDeleteClick = deleteImageFile
+                                onDeleteClick = deleteImageFile,
+                                dateString = state.diaryDate.toString(),
+                                positionString = "${index + 1}/${state.imageFiles.size}"
                             )
                         } else {
                             EmptyPolaroidView(

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -213,10 +213,10 @@ fun DiaryWriteScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .weight(1f)
-                        .padding(16.dp)
+                        .padding(horizontal = 16.dp)
                         .verticalScroll(scrollState)
                 ) {
-                    Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(24.dp))
 
                     Text(text = state.diaryDate.toString())
 
@@ -395,6 +395,8 @@ fun DiaryWriteScreen(
                             }
                         )
                     }
+
+                    Spacer(modifier = Modifier.height(16.dp))
                 }
             } else if (state.showInitLoading) {
                 Box(

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -41,6 +41,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import com.strayalphaca.presentation.components.atom.text_button.TextButtonState
 import com.strayalphaca.presentation.components.block.EmptyPolaroidView
+import com.strayalphaca.presentation.components.block.EmptySoundView
 import com.strayalphaca.presentation.components.template.dialog.DiaryLocationPickerDialog
 import com.strayalphaca.presentation.components.template.error_view.ErrorView
 import com.strayalphaca.travel_diary.diary.model.Feeling
@@ -377,15 +378,21 @@ fun DiaryWriteScreen(
 
                     Spacer(modifier = Modifier.height(24.dp))
 
-                    state.voiceFile?.let { mediaFileInDiary ->
+                    if (state.voiceFile != null) {
                         SoundView(
-                            file = mediaFileInDiary.uri,
+                            file = state.voiceFile.uri,
                             playing = state.musicPlaying,
                             play = playMusic,
                             pause = pauseMusic,
                             remove = removeVoiceFile,
                             soundProgressChange = changeMusicProgress,
                             soundProgress = musicProgress
+                        )
+                    } else {
+                        EmptySoundView(
+                            onClick = {
+                                mp3PickerLauncher.launch("audio/*")
+                            }
                         )
                     }
                 }
@@ -402,28 +409,6 @@ fun DiaryWriteScreen(
                 }
             } else {
                 ErrorView(modifier = Modifier.fillMaxSize())
-            }
-
-            Column(modifier = Modifier.fillMaxWidth()) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(1.dp)
-                        .background(Gray2)
-                )
-
-                Row(
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-
-                    BaseIconButton(
-                        iconResourceId = R.drawable.ic_music,
-                        onClick = {
-                            mp3PickerLauncher.launch("audio/*")
-                        }
-                    )
-
-                }
             }
 
         }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="modify">수정하기</string>
     <string name="delete">삭제하기</string>
     <string name="retry">다시 시도하기</string>
+    <string name="add_image">사진 추가하기</string>
 
     <string name="time_pm">오후 %02d:%02d</string>
     <string name="time_am">오전 %02d:%02d</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="delete">삭제하기</string>
     <string name="retry">다시 시도하기</string>
     <string name="add_image">사진 추가하기</string>
+    <string name="add_audio">녹음 파일 추가하기</string>
 
     <string name="time_pm">오후 %02d:%02d</string>
     <string name="time_am">오전 %02d:%02d</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="retry">다시 시도하기</string>
     <string name="add_image">사진 추가하기</string>
     <string name="add_audio">녹음 파일 추가하기</string>
+    <string name="waiting_update_diary">일지 작성 내용을 반영하고 있습니다.\n잠시만 기다려 주세요</string>
 
     <string name="time_pm">오후 %02d:%02d</string>
     <string name="time_am">오전 %02d:%02d</string>


### PR DESCRIPTION
일지 작성화면에서 아래 항목들을 수정
- 사진/동영상 추가 및 음성 파일 추가 관련 UI 변경
- 사진/동영상 표시 UI에서 작성일자와 사진의 인덱스 텍스트가 항상 상수값으로 보였던 부분 수정
  - 이제 작성 일자와 사진의 인덱스 정보(예시. "1/3")이 정상적으로 표기됩니다.
- 가로 모드로 찍은 사진에 대해서 compress한 결과 사진이 회전되어서 전송되던 현상 수정
- 수정/작성 api 호출 후 대기하는 동안 뒤로가기/이미지선택/음성선택이 불가능하다록 수정