### PR TITLE
[fix] 회원가입, 로그인, 인증코드 발송/재발송 useCase 내 입력 문자열의 공백을 제거하는 부분 추가

### DIFF
--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
@@ -2,12 +2,14 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseCheckAuthCode @Inject constructor(
     private val repository: LoginRepository
 ) {
     suspend operator fun invoke(email : String, authCode : String): BaseResponse<Nothing> {
-        return repository.checkAuthCode(email, authCode)
+        val emailWithoutSpace = email.removeWhiteSpace()
+        return repository.checkAuthCode(emailWithoutSpace, authCode)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -4,16 +4,18 @@ import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
+import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseIssueAuthCode @Inject constructor(
     private val repository: LoginRepository
 ) {
     suspend operator fun invoke(email : String) : BaseResponse<Nothing> {
-        if (!isEmailFormat(email)) {
+        val emailWithoutSpace = email.removeWhiteSpace()
+        if (!isEmailFormat(emailWithoutSpace)) {
             return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
         }
 
-        return repository.issueAuthCode(email)
+        return repository.issueAuthCode(emailWithoutSpace)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
@@ -5,19 +5,23 @@ import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
+import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseLogin @Inject constructor(
     private val repository : LoginRepository
 ) {
     suspend operator fun invoke(email : String, password : String) : BaseResponse<Tokens> {
-        if (email.isEmpty() || password.isEmpty()) {
+        val emailWithoutSpace = email.removeWhiteSpace()
+        val passwordWithoutSpace = password.removeWhiteSpace()
+
+        if (emailWithoutSpace.isEmpty() || passwordWithoutSpace.isEmpty()) {
             return BaseResponse.Failure(errorCode = LoginErrorCodes.INPUT_EMAIL_AND_PASSWORD, errorMessage = "이메일/비밀번호를 입력해 주세요.")
         }
-        if (!isEmailFormat(email)) {
+        if (!isEmailFormat(emailWithoutSpace)) {
             return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
         }
 
-        return repository.emailLogin(email, password)
+        return repository.emailLogin(emailWithoutSpace, passwordWithoutSpace)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseSignup.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseSignup.kt
@@ -2,12 +2,16 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseSignup @Inject constructor(
     private val repository: LoginRepository
 ) {
     suspend operator fun invoke(email : String, password : String) : BaseResponse<String> {
-        return repository.emailSignup(email, password)
+        val emailWithoutSpace = email.removeWhiteSpace()
+        val passwordWithoutSpace = password.removeWhiteSpace()
+
+        return repository.emailSignup(emailWithoutSpace, passwordWithoutSpace)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/utils/stringUtils.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/utils/stringUtils.kt
@@ -1,0 +1,6 @@
+package com.strayalphaca.travel_diary.domain.login.utils
+
+
+internal fun String.removeWhiteSpace() : String {
+    return this.replace("\\s".toRegex(), "")
+}


### PR DESCRIPTION
- 로그인/회원가입/인증번호 발급시 입력한 이메일값에 공백이 있을 경우 해당 공백을 제거한 값만을 사용하게 됩니다.