### PR TITLE
Fix calendar UI

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarScreen.kt
@@ -1,38 +1,36 @@
 package com.strayalphaca.presentation.screens.home.calendar
 
 import android.widget.Toast
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.pager.HorizontalPager
-import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material.MaterialTheme
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.strayalphaca.presentation.components.block.CalendarItemEmptyView
-import com.strayalphaca.presentation.components.block.CalendarItemView
-import com.strayalphaca.presentation.components.template.calendar_view.CalendarView
-import com.strayalphaca.presentation.components.template.dialog.MonthPickerDialog
-import com.strayalphaca.presentation.R
-import com.strayalphaca.presentation.components.atom.base_icon_button.BaseIconButton
 import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.presentation.components.template.dialog.MonthPickerDialog
+import com.strayalphaca.presentation.screens.home.calendar.component.CalendarUi
+import com.strayalphaca.presentation.screens.home.calendar.component.ToolButtons
+import com.strayalphaca.presentation.screens.home.calendar.component.YearMonthText
 import com.strayalphaca.presentation.utils.UseFinishByBackPressTwice
 import com.strayalphaca.presentation.utils.collectLatestInScope
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CalendarScreen(
     modifier: Modifier = Modifier,
@@ -42,7 +40,6 @@ fun CalendarScreen(
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     var datePickerDialogShow by remember { mutableStateOf(false) }
-    val pagerState = rememberPagerState(Int.MAX_VALUE / 2)
     val context = LocalContext.current
     val composeScope = rememberCoroutineScope()
 
@@ -80,75 +77,29 @@ fun CalendarScreen(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
+                YearMonthText(
                     modifier = Modifier.weight(1f),
-                    verticalAlignment = Alignment.Bottom
-                ) {
-                    Text(text = state.month.toString(), style = MaterialTheme.typography.h1)
-
-                    Spacer(modifier = Modifier.width(8.dp))
-
-                    Text(text = state.year.toString(), style = MaterialTheme.typography.h2)
-                }
-
-                BaseIconButton(
-                    iconResourceId = R.drawable.ic_write,
-                    onClick = {
-                        if (!state.clickEnable) return@BaseIconButton
-                        viewModel.checkTodayWrite()
-                    }
+                    year = state.year,
+                    month = state.month
                 )
 
-                Spacer(modifier = Modifier.width(8.dp))
-
-                BaseIconButton(
-                    iconResourceId = R.drawable.ic_calendar,
-                    onClick = {
-                        if (!state.clickEnable) return@BaseIconButton
-                        datePickerDialogShow = true
-                    }
+                ToolButtons(
+                    onClickCalendarButton = viewModel::checkTodayWrite,
+                    onClickWrite = { datePickerDialogShow = true },
+                    enable = state.clickEnable
                 )
             }
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            HorizontalPager(
-                pageCount = 1,
-                state = pagerState
-            ) {
-                CalendarView(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 24.dp),
-                    year = state.year,
-                    month = state.month,
-                    calendarData = state.diaryData,
-                    contentView = { data, _, isToday ->
-                        CalendarItemView(item = data, isToday = isToday,
-                            modifier = Modifier.clickable {
-                                if (!state.clickEnable) return@clickable
-                                goToDiaryDetail(data.id)
-                            })
-                    },
-                    emptyView = { day, isToday ->
-                        CalendarItemEmptyView(day = day, isToday = isToday,
-                            modifier = Modifier.clickable {
-                                if (!state.clickEnable) return@clickable
-                                goToDiaryWrite(
-                                    null,
-                                    DiaryDate(year = state.year, month = state.month, day = day).toString()
-                                )
-                            }
-                        )
-                    },
-                    outRangeView = { day ->
-                        if (!state.clickEnable) return@CalendarView
-                        CalendarItemEmptyView(day = day, isToday = false, isCurrentMonth = false)
-                    }
-                )
-            }
-
-
+            CalendarUi(
+                goToDiaryDetail = goToDiaryDetail,
+                goToDiaryWrite = goToDiaryWrite,
+                year = state.year,
+                month = state.month,
+                diaryData = state.diaryData,
+                enable = state.clickEnable
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarScreen.kt
@@ -1,14 +1,18 @@
 package com.strayalphaca.presentation.screens.home.calendar
 
+import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -20,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -28,8 +33,10 @@ import com.strayalphaca.presentation.components.template.dialog.MonthPickerDialo
 import com.strayalphaca.presentation.screens.home.calendar.component.CalendarUi
 import com.strayalphaca.presentation.screens.home.calendar.component.ToolButtons
 import com.strayalphaca.presentation.screens.home.calendar.component.YearMonthText
+import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import com.strayalphaca.presentation.utils.UseFinishByBackPressTwice
 import com.strayalphaca.presentation.utils.collectLatestInScope
+import com.strayalphaca.travel_diary.domain.calendar.utils.fillEmptyCellToCalendarData
 
 @Composable
 fun CalendarScreen(
@@ -69,37 +76,167 @@ fun CalendarScreen(
     Surface(
         modifier = Modifier.fillMaxSize()
     ) {
-        Column(modifier = modifier.padding(vertical = 48.dp)) {
+        BoxWithConstraints {
+            if (maxWidth < 600.dp) {
+                Column(modifier = modifier.padding(vertical = 48.dp)) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 24.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        YearMonthText(
+                            modifier = Modifier.weight(1f),
+                            year = state.year,
+                            month = state.month
+                        )
+
+                        ToolButtons(
+                            onClickCalendarButton = { datePickerDialogShow = true },
+                            onClickWrite = viewModel::checkTodayWrite,
+                            enable = state.clickEnable
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(32.dp))
+
+                    CalendarUi(
+                        goToDiaryDetail = goToDiaryDetail,
+                        goToDiaryWrite = goToDiaryWrite,
+                        year = state.year,
+                        month = state.month,
+                        diaryData = state.diaryData,
+                        enable = state.clickEnable
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ){
+                    Column(
+                        modifier = Modifier.fillMaxHeight()
+                    ) {
+                        Spacer(modifier = Modifier.height(128.dp))
+
+                        ToolButtons(
+                            onClickCalendarButton = { datePickerDialogShow = true },
+                            onClickWrite = viewModel::checkTodayWrite,
+                            enable = state.clickEnable
+                        )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        YearMonthText(
+                            year = state.year,
+                            month = state.month
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(60.dp))
+
+                    CalendarUi(
+                        goToDiaryDetail = goToDiaryDetail,
+                        goToDiaryWrite = goToDiaryWrite,
+                        year = state.year,
+                        month = state.month,
+                        diaryData = state.diaryData,
+                        enable = state.clickEnable
+                    )
+                }
+            }
+        }
+
+
+    }
+}
+
+
+@Composable
+@Preview(
+    showBackground = true,
+    widthDp = 360,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "dark"
+)
+@Preview(showBackground = true, widthDp = 360)
+fun CalendarScreenPreview() {
+    TravelDiaryTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            Column(modifier = Modifier.padding(vertical = 48.dp)) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    YearMonthText(
+                        modifier = Modifier.weight(1f),
+                        year = 2023,
+                        month = 12
+                    )
+
+                    ToolButtons(enable = true)
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                CalendarUi(
+                    diaryData = fillEmptyCellToCalendarData(2023, 12, emptyList())
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+@Preview(
+    showBackground = true,
+    widthDp = 690,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "dark"
+)
+@Preview(showBackground = true, widthDp = 690)
+fun CalendarScreenTabletPreview() {
+    TravelDiaryTheme {
+        Surface(
+            modifier = Modifier.fillMaxSize()
+        ) {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 24.dp),
+                modifier = Modifier.padding(24.dp),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
-            ) {
-                YearMonthText(
-                    modifier = Modifier.weight(1f),
-                    year = state.year,
-                    month = state.month
-                )
+            ){
+                Column(
+                    modifier = Modifier.fillMaxHeight()
+                ) {
+                    Spacer(modifier = Modifier.height(128.dp))
 
-                ToolButtons(
-                    onClickCalendarButton = viewModel::checkTodayWrite,
-                    onClickWrite = { datePickerDialogShow = true },
-                    enable = state.clickEnable
+                    ToolButtons(enable = true)
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    YearMonthText(
+                        year = 2023,
+                        month = 12
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(60.dp))
+
+                CalendarUi(
+                    modifier = Modifier.weight(1f),
+                    diaryData = fillEmptyCellToCalendarData(2023, 12, emptyList())
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
 
-            CalendarUi(
-                goToDiaryDetail = goToDiaryDetail,
-                goToDiaryWrite = goToDiaryWrite,
-                year = state.year,
-                month = state.month,
-                diaryData = state.diaryData,
-                enable = state.clickEnable
-            )
         }
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/CalendarUi.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/CalendarUi.kt
@@ -60,7 +60,6 @@ internal fun CalendarUi(
                 )
             },
             outRangeView = { day ->
-                if (!enable) return@CalendarView
                 CalendarItemEmptyView(day = day, isToday = false, isCurrentMonth = false)
             }
         )

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/CalendarUi.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/CalendarUi.kt
@@ -1,0 +1,68 @@
+package com.strayalphaca.presentation.screens.home.calendar.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.strayalphaca.domain.all.DiaryDate
+import com.strayalphaca.presentation.components.block.CalendarItemEmptyView
+import com.strayalphaca.presentation.components.block.CalendarItemView
+import com.strayalphaca.presentation.components.template.calendar_view.CalendarView
+import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
+
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun CalendarUi(
+    modifier : Modifier = Modifier,
+    goToDiaryWrite: (String?, String?) -> Unit = { _, _ ->},
+    goToDiaryDetail: (String) -> Unit = {},
+    year : Int = 2023,
+    month : Int = 12,
+    diaryData : List<DiaryInCalendar?> = emptyList(),
+    enable : Boolean = true
+) {
+    val pagerState = rememberPagerState(Int.MAX_VALUE / 2)
+
+    HorizontalPager(
+        pageCount = 1,
+        state = pagerState,
+        modifier = modifier
+    ) {
+        CalendarView(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            year = year,
+            month = month,
+            calendarData = diaryData,
+            contentView = { data, _, isToday ->
+                CalendarItemView(item = data, isToday = isToday,
+                    modifier = Modifier.clickable {
+                        if (!enable) return@clickable
+                        goToDiaryDetail(data.id)
+                    })
+            },
+            emptyView = { day, isToday ->
+                CalendarItemEmptyView(day = day, isToday = isToday,
+                    modifier = Modifier.clickable {
+                        if (!enable) return@clickable
+                        goToDiaryWrite(
+                            null,
+                            DiaryDate(year = year, month = month, day = day).toString()
+                        )
+                    }
+                )
+            },
+            outRangeView = { day ->
+                if (!enable) return@CalendarView
+                CalendarItemEmptyView(day = day, isToday = false, isCurrentMonth = false)
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/ToolButtons.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/ToolButtons.kt
@@ -1,0 +1,38 @@
+package com.strayalphaca.presentation.screens.home.calendar.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.strayalphaca.presentation.R
+import com.strayalphaca.presentation.components.atom.base_icon_button.BaseIconButton
+
+@Composable
+internal fun ToolButtons(
+    modifier : Modifier = Modifier,
+    onClickWrite : () -> Unit = {},
+    onClickCalendarButton : () -> Unit = {},
+    enable: Boolean
+) {
+    Row(modifier) {
+        BaseIconButton(
+            iconResourceId = R.drawable.ic_write,
+            onClick = {
+                if (!enable) return@BaseIconButton
+                onClickWrite()
+            }
+        )
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        BaseIconButton(
+            iconResourceId = R.drawable.ic_calendar,
+            onClick = {
+                if (!enable) return@BaseIconButton
+                onClickCalendarButton()
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/YearMonthText.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/component/YearMonthText.kt
@@ -1,0 +1,29 @@
+package com.strayalphaca.presentation.screens.home.calendar.component
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun YearMonthText(
+    modifier : Modifier = Modifier,
+    year : Int,
+    month : Int
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.Bottom
+    ) {
+        Text(text = month.toString(), style = MaterialTheme.typography.h1)
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        Text(text = year.toString(), style = MaterialTheme.typography.h2)
+    }
+}


### PR DESCRIPTION
달력 화면 UI관련 다음 내용들을 수정함
- 달력 화면을 구성하는 요소를 크게 3가지로 나누어 분리
  - 달력 UI
  - 년도/월 표시 Text
  - 일지 작성, 날짜 변경 버튼 Row
- 태블릿, 갤럭시 폴드같이 가로 크기가 600dp 이상인 기기에 대한 UI 추가
- 작성 버튼 클릭시 이전/이후 달의 날짜부분이 깜빡이던 현상 수정