### PR TITLE
Fix withdrawal

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalScreen.kt
@@ -2,6 +2,8 @@ package com.strayalphaca.presentation.screens.settings.withdrawal
 
 import android.widget.Toast
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -30,6 +32,7 @@ fun WithdrawalScreen(
         viewModel.initDataLoading()
     }
 
+    val scrollState = rememberScrollState()
     val localContext = LocalContext.current
     val diaryCount by viewModel.totalDiaryCount.collectAsStateWithLifecycle()
     val initLoading by viewModel.initDataLoading.collectAsStateWithLifecycle()
@@ -73,41 +76,49 @@ fun WithdrawalScreen(
         Column(modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 32.dp)) {
-            Spacer(modifier = Modifier.height(12.dp))
 
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(scrollState)
             ) {
-                Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.current_login))
-                Text(style = MaterialTheme.typography.body1, text = "")
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.current_login))
+                    Text(style = MaterialTheme.typography.body1, text = "")
+                }
+
+                Row(modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 12.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.my_diaries))
+                    Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.total_count_format, diaryCount))
+                }
+
+                Spacer(modifier = Modifier.height(60.dp))
+
+                Text(
+                    style = MaterialTheme.typography.body1,
+                    text = stringResource(id = R.string.caution)
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Text(
+                    style = MaterialTheme.typography.body2,
+                    text = stringResource(id = R.string.withdrawal_caution_message)
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
             }
 
-            Row(modifier = Modifier
-                .fillMaxWidth()
-                .padding(vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.my_diaries))
-                Text(style = MaterialTheme.typography.body1, text = stringResource(id = R.string.total_count_format, diaryCount))
-            }
-
-            Spacer(modifier = Modifier.height(60.dp))
-
-            Text(
-                style = MaterialTheme.typography.body1,
-                text = stringResource(id = R.string.caution)
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Text(
-                style = MaterialTheme.typography.body2,
-                text = stringResource(id = R.string.withdrawal_caution_message)
-            )
-
-            Spacer(modifier = Modifier.weight(1f))
 
             BaseButton(
                 modifier = Modifier

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseWithdrawal
 import com.strayalphaca.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryCount
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -15,7 +15,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class WithdrawalViewModel @Inject constructor(
-    private val useCaseWithdrawal: UseCaseWithdrawal
+    private val useCaseWithdrawal: UseCaseWithdrawal,
+    private val useCaseGetDiaryCount: UseCaseGetDiaryCount
 ) : ViewModel() {
     private val _totalDiaryCount = MutableStateFlow(0)
     val totalDiaryCount = _totalDiaryCount.asStateFlow()
@@ -38,7 +39,10 @@ class WithdrawalViewModel @Inject constructor(
     fun initDataLoading() {
         _initDataLoading.value = true
         viewModelScope.launch {
-            delay(1000L)
+            val response = useCaseGetDiaryCount()
+            if (response is BaseResponse.Success<Int>) {
+                _totalDiaryCount.value = response.data
+            }
             _initDataLoading.value = false
         }
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseWithdrawal
 import com.strayalphaca.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryCount
+import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseClearToken
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,7 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class WithdrawalViewModel @Inject constructor(
     private val useCaseWithdrawal: UseCaseWithdrawal,
-    private val useCaseGetDiaryCount: UseCaseGetDiaryCount
+    private val useCaseGetDiaryCount: UseCaseGetDiaryCount,
+    private val useCaseClearToken: UseCaseClearToken
 ) : ViewModel() {
     private val _totalDiaryCount = MutableStateFlow(0)
     val totalDiaryCount = _totalDiaryCount.asStateFlow()
@@ -52,6 +54,7 @@ class WithdrawalViewModel @Inject constructor(
         viewModelScope.launch {
             val res = useCaseWithdrawal()
             if (res is BaseResponse.EmptySuccess) {
+                useCaseClearToken()
                 _deleteLoading.value = false
                 _withdrawalSuccess.emit(true)
             } else {


### PR DESCRIPTION
- 회원탈퇴 화면에서 그동안 작성했던 일지의 개수를 표시하도록 구현
- 회원탈퇴 성공 후 토큰을 제거하지 않았던 문제 수정
- z 플립의 플랙스 모드를 강제로 실행했을 때를 대비하여, 회원탈퇴 화면이 스크롤 가능하도록 수정