### PR TITLE
Fix UI

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/EditTextWithTitle.kt
@@ -41,7 +41,7 @@ fun EditTextWithTitle(
     placeHolder : String,
     value : String,
     errorText : String = "",
-    isError : Boolean = false,
+    showErrorText : Boolean = false,
     state : EditTextState = EditTextState.ACTIVE,
     type : EditTextType = EditTextType.NORMAL,
     onValueChange : (newValue : String) -> Unit = {}
@@ -79,7 +79,7 @@ fun EditTextWithTitle(
                 .height(1.dp)
                 .background(MaterialTheme.colors.onBackground)
         )
-        if (isError) {
+        if (showErrorText) {
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = errorText, style = MaterialTheme.typography.caption.copy(color = MaterialTheme.colors.error))
         }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/intro/IntroScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/intro/IntroScreen.kt
@@ -11,6 +11,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -21,6 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.strayalphaca.presentation.R
 import com.strayalphaca.presentation.components.atom.base_button.BaseButton
 import com.strayalphaca.presentation.components.atom.text_button.TextButton
+import com.strayalphaca.presentation.components.template.dialog.OneButtonDialog
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import com.strayalphaca.presentation.utils.UseFinishByBackPressTwice
 
@@ -30,6 +35,20 @@ fun IntroScreen(
     goToHome : () -> Unit = {}
 ) {
     UseFinishByBackPressTwice()
+    var showOfflineOverviewDialog by remember { mutableStateOf(false) }
+
+    if (showOfflineOverviewDialog) {
+        OneButtonDialog(
+            title = stringResource(id = R.string.look_around_guide),
+            mainText = stringResource(id = R.string.look_around_guide_text),
+            buttonText = stringResource(id = R.string.check),
+            buttonClick = {
+                showOfflineOverviewDialog = false
+                goToHome()
+            },
+            onDismissRequest = { showOfflineOverviewDialog = false }
+        )
+    }
 
     Surface(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -77,7 +96,7 @@ fun IntroScreen(
             TextButton(
                 text = stringResource(id = R.string.continue_offline),
                 modifier = Modifier.padding(horizontal = 32.dp),
-                onClick = { goToHome() }
+                onClick = { showOfflineOverviewDialog = true }
             )
 
             Spacer(modifier = Modifier.weight(0.25f))

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginScreen.kt
@@ -21,7 +21,6 @@ import com.strayalphaca.presentation.components.atom.text_button.TextButton
 import com.strayalphaca.presentation.components.block.EditTextWithTitle
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.graphics.Color
 import com.strayalphaca.presentation.components.block.EditTextType
 import com.strayalphaca.presentation.utils.collectAsEffect
 
@@ -81,6 +80,8 @@ fun LoginScreen(
                     value = password,
                     onValueChange = viewModel::inputPassword,
                     type = EditTextType.PASSWORD,
+                    showErrorText = true,
+                    errorText = errorMessage
                 )
 
                 Spacer(modifier = Modifier.height(24.dp))
@@ -98,11 +99,6 @@ fun LoginScreen(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Text(
-                        modifier = Modifier.padding(vertical = 12.dp),
-                        text = errorMessage,
-                        style = MaterialTheme.typography.body2.copy(color = Color.Red)
-                    )
 
                     Spacer(modifier = Modifier.weight(1f))
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/change_password/ChangePasswordScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/change_password/ChangePasswordScreen.kt
@@ -63,7 +63,7 @@ fun ChangePasswordScreen(
             value = newPassword,
             onValueChange = viewModel::inputNewPassword,
             state = if(screenState.buttonEnable) EditTextState.ACTIVE else EditTextState.INACTIVE,
-            isError = screenState.errorMessage.isNotEmpty(),
+            showErrorText = screenState.errorMessage.isNotEmpty(),
             errorText = screenState.errorMessage
         )
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -66,7 +66,9 @@
 
     <string name="hello">안녕하세요!</string>
     <string name="intro">추억을 담는 여정,\nTraily에 오신 것을 환영합니다</string>
-    <string name="continue_offline">비회원으로 계속하기</string>
+    <string name="continue_offline">비회원으로 둘러보기</string>
+    <string name="look_around_guide">둘러보기 안내</string>
+    <string name="look_around_guide_text">둘러보기 기능은 오직 체험용도로 사용되며, 일지 작성/수정/삭제와 같은 기능은 지원하지 않습니다.\n로그인을 원하시는 경우 하단 오른쪽에 있는 설정버튼 클릭->로그인 클릭을 통해 로그인 화면으로 이동할 수 있습니다.</string>
 
     <string name="select_date">날짜 선택</string>
     <string name="cancel">취소</string>


### PR DESCRIPTION
- EditTextWithTitle 컴포넌트의 에러 텍스트를 표시하는 인자 이름을 isError에서 showErrorText로 변경
- 로그인 화면에서 로그인 실패시 에러 텍스트가 표시될 때, 같은 row에 있는 "비밀번호 찾기", "회원가입" 버튼이 비정상적으로 보이는 문제를 해결하기 위해, UI구조를 변경하여 로그인 실패시 에러 텍스트가 비밀번호를 입력하는 EditTextWithTitle의 에러 텍스트로 표시되도록 UI 수정
- 인트로 화면에서 "비회원으로 계속하기"를 "비회원으로 둘러보기"로 변경
- 인트로 화면에서 "비회원으로 둘러보기" 클릭시 체험 기능만 제공함을 알려주는 다이얼로그 추가