### PR TITLE
create and apply errorcode mapper

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
@@ -1,15 +1,21 @@
 package com.strayalphaca.travel_diary.di
 
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.DefaultErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.diary.DiaryErrorCodeMapper
 import com.strayalphaca.travel_diary.data.diary.data_source.DiaryDataSource
 import com.strayalphaca.travel_diary.data.diary.data_source.DiaryTestDataSource
 import com.strayalphaca.travel_diary.data.diary.repository_impl.DiaryRepositoryImpl
 import com.strayalphaca.travel_diary.data.diary.repository_impl.RemoteDiaryRepository
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 
@@ -35,5 +41,13 @@ object DiaryProvideModule {
         } else {
             DiaryRepositoryImpl(diaryDataSource)
         }
+    }
+
+    @DiaryErrorCodeMapperProvide
+    @Provides
+    fun provideDiaryErrorCodeMapper(
+        @ApplicationContext context : Context
+    ) : ErrorCodeMapper {
+        return DefaultErrorCodeMapper(DiaryErrorCodeMapper(context), context)
     }
 }

--- a/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
@@ -1,12 +1,22 @@
 package com.strayalphaca.travel_diary.di
 
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.DefaultErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.login.AuthCodeErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.login.LoginErrorCodeMapper
+import com.strayalphaca.presentation.models.error_code_mapper.login.SignupErrorCodeMapper
 import com.strayalphaca.travel_diary.data.login.data_source.LoginDataSource
 import com.strayalphaca.travel_diary.data.login.data_source.LoginTestDataSource
 import com.strayalphaca.travel_diary.data.login.repository_impl.RemoteLoginRepository
+import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.di.LoginErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.di.SignupErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 
@@ -21,5 +31,29 @@ object LoginModule {
     @Provides
     fun provideLoginDataSource() : LoginDataSource {
         return LoginTestDataSource()
+    }
+
+    @LoginErrorCodeMapperProvide
+    @Provides
+    fun provideLoginErrorCodeMapper(
+        @ApplicationContext context : Context
+    ) : ErrorCodeMapper {
+        return DefaultErrorCodeMapper(LoginErrorCodeMapper(context), context)
+    }
+
+    @SignupErrorCodeMapperProvide
+    @Provides
+    fun provideSignupErrorCodeMapper(
+        @ApplicationContext context : Context
+    ) : ErrorCodeMapper {
+        return DefaultErrorCodeMapper(SignupErrorCodeMapper(context), context)
+    }
+
+    @AuthCodeErrorCodeMapperProvide
+    @Provides
+    fun provideAuthCodeErrorCodeMapper(
+        @ApplicationContext context : Context
+    ) : ErrorCodeMapper {
+        return DefaultErrorCodeMapper(AuthCodeErrorCodeMapper(context), context)
     }
 }

--- a/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
@@ -12,6 +12,7 @@ import com.strayalphaca.travel_diary.data.login.repository_impl.RemoteLoginRepos
 import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.di.LoginErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.di.SignupErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.di.WithdrawalErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import dagger.Module
 import dagger.Provides
@@ -55,5 +56,13 @@ object LoginModule {
         @ApplicationContext context : Context
     ) : ErrorCodeMapper {
         return DefaultErrorCodeMapper(AuthCodeErrorCodeMapper(context), context)
+    }
+
+    @WithdrawalErrorCodeMapperProvide
+    @Provides
+    fun provideWithdrawalErrorCodeMapper(
+        @ApplicationContext context : Context
+    ) : ErrorCodeMapper {
+        return DefaultErrorCodeMapper(null, context)
     }
 }

--- a/core/domain/src/main/java/com/strayalpaca/travel_diary/core/domain/model/BaseResponse.kt
+++ b/core/domain/src/main/java/com/strayalpaca/travel_diary/core/domain/model/BaseResponse.kt
@@ -11,4 +11,12 @@ sealed class BaseResponse<out T> {
     ) : BaseResponse<Nothing>()
 
     object EmptySuccess : BaseResponse<Nothing>()
+
+    fun mapErrorCodeToMessageIfFailure(errorCodeMapper : (Int) -> String) : BaseResponse<T> {
+        return if (this is Failure) {
+            this.copy(errorMessage = errorCodeMapper(errorCode))
+        } else {
+            this
+        }
+    }
 }

--- a/core/domain/src/main/java/com/strayalpaca/travel_diary/core/domain/model/ErrorCodeMapper.kt
+++ b/core/domain/src/main/java/com/strayalpaca/travel_diary/core/domain/model/ErrorCodeMapper.kt
@@ -1,0 +1,5 @@
+package com.strayalpaca.travel_diary.core.domain.model
+
+interface ErrorCodeMapper {
+    fun mapCodeToString(errorCode : Int) : String
+}

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/di/ErrorCodeMapperProvide.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/di/ErrorCodeMapperProvide.kt
@@ -1,0 +1,7 @@
+package com.strayalphaca.travel_diary.diary.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DiaryErrorCodeMapperProvide

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/model/DiaryErrorCodes.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/model/DiaryErrorCodes.kt
@@ -2,5 +2,4 @@ package com.strayalphaca.travel_diary.diary.model
 
 object DiaryErrorCodes {
     const val EMPTY_ARGUMENT_DIARY_CONTENT = 1
-    const val ALREADY_EXIST_TODAY_DIARY = 2
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseDeleteDiary.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseDeleteDiary.kt
@@ -1,10 +1,17 @@
 package com.strayalphaca.travel_diary.diary.use_case
 
+import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import javax.inject.Inject
 
 class UseCaseDeleteDiary @Inject constructor(
-    private val repository : DiaryRepository
+    private val repository : DiaryRepository,
+    @DiaryErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
-    suspend operator fun invoke(diaryId : String) = repository.deleteDiary(diaryId)
+    suspend operator fun invoke(diaryId : String) : BaseResponse<Nothing> {
+        val response = repository.deleteDiary(diaryId)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
+    }
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseGetDiaryCount.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseGetDiaryCount.kt
@@ -1,13 +1,17 @@
 package com.strayalphaca.travel_diary.diary.use_case
 
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import javax.inject.Inject
 
 class UseCaseGetDiaryCount @Inject constructor(
-    private val repository : DiaryRepository
+    private val repository : DiaryRepository,
+    @DiaryErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
     suspend operator fun invoke() : BaseResponse<Int> {
-        return repository.getDiaryCount()
+        val response = repository.getDiaryCount()
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseGetDiaryDetail.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseGetDiaryDetail.kt
@@ -3,12 +3,16 @@ package com.strayalphaca.travel_diary.diary.use_case
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import javax.inject.Inject
 
 class UseCaseGetDiaryDetail @Inject constructor(
-    private val repository: DiaryRepository
+    private val repository: DiaryRepository,
+    @DiaryErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
     suspend operator fun invoke(id : String) : BaseResponse<DiaryDetail> {
-        return repository.getDiaryDetail(id)
+        val response = repository.getDiaryDetail(id)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseModifyDiary.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseModifyDiary.kt
@@ -3,17 +3,22 @@ package com.strayalphaca.travel_diary.diary.use_case
 import com.strayalphaca.travel_diary.diary.model.DiaryModifyData
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.diary.model.DiaryErrorCodes
 import javax.inject.Inject
 
 class UseCaseModifyDiary @Inject constructor(
-    private val repository: DiaryRepository
+    private val repository: DiaryRepository,
+    @DiaryErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
     suspend operator fun invoke(diaryModifyData: DiaryModifyData) : BaseResponse<Nothing> {
         if (diaryModifyData.content == "") {
-            return BaseResponse.Failure(errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT, errorMessage = "")
+            val errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT
+            return BaseResponse.Failure(errorCode = errorCode, errorMessage = errorCodeMapper.mapCodeToString(errorCode))
         }
 
-        return repository.modifyDiary(diaryModifyData)
+        val response = repository.modifyDiary(diaryModifyData)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseUploadDiary.kt
+++ b/domain/diary/src/main/java/com/strayalphaca/travel_diary/diary/use_case/UseCaseUploadDiary.kt
@@ -3,17 +3,22 @@ package com.strayalphaca.travel_diary.diary.use_case
 import com.strayalphaca.travel_diary.diary.model.DiaryWriteData
 import com.strayalphaca.travel_diary.diary.repository.DiaryRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.diary.di.DiaryErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.diary.model.DiaryErrorCodes
 import javax.inject.Inject
 
 class UseCaseUploadDiary @Inject constructor(
-    private val repository: DiaryRepository
+    private val repository: DiaryRepository,
+    @DiaryErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
     suspend operator fun invoke(diaryWriteData: DiaryWriteData) : BaseResponse<String> {
         if (diaryWriteData.content.isEmpty()) {
-            return BaseResponse.Failure(errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT, errorMessage = "")
+            val errorCode = DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT
+            return BaseResponse.Failure(errorCode = errorCode, errorMessage = errorCodeMapper.mapCodeToString(errorCode))
         }
 
-        return repository.uploadDiary(diaryWriteData)
+        val response = repository.uploadDiary(diaryWriteData)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/di/ErrorCodeMapperProvide.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/di/ErrorCodeMapperProvide.kt
@@ -1,0 +1,15 @@
+package com.strayalphaca.travel_diary.domain.login.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class LoginErrorCodeMapperProvide
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class SignupErrorCodeMapperProvide
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class AuthCodeErrorCodeMapperProvide

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/di/ErrorCodeMapperProvide.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/di/ErrorCodeMapperProvide.kt
@@ -13,3 +13,7 @@ annotation class SignupErrorCodeMapperProvide
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class AuthCodeErrorCodeMapperProvide
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class WithdrawalErrorCodeMapperProvide

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/LoginErrorCodes.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/LoginErrorCodes.kt
@@ -1,10 +1,8 @@
 package com.strayalphaca.travel_diary.domain.login.model
 
 object LoginErrorCodes {
-    const val INPUT_EMAIL_AND_PASSWORD = 1
+    const val EMPTY_EMAIL_OR_PASSWORD = 1
     const val INVALID_EMAIL_FORMAT = 2
-    const val EXIST_EMAIL = 3
-    const val INVALID_EMAIL_OR_PASSWORD = 4
-    const val DAILY_LIMIT_EXCEEDED_ISSUE_AUTH_CODE = 5
-    const val INVALID_AUTH_CODE = 5
+    const val INVALID_AUTH_CODE_FORMAT = 3
+    const val EMPTY_PASSWORD = 4
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
@@ -2,14 +2,38 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_AUTH_CODE_FORMAT
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_EMAIL_FORMAT
+import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseCheckAuthCode @Inject constructor(
-    private val repository: LoginRepository
+    private val repository: LoginRepository,
+    @AuthCodeErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
     suspend operator fun invoke(email : String, authCode : String): BaseResponse<Nothing> {
         val emailWithoutSpace = email.removeWhiteSpace()
-        return repository.checkAuthCode(emailWithoutSpace, authCode)
+        val authCodeWithoutSpace = authCode.removeWhiteSpace()
+
+        val clientSideErrorCode = getClientSideErrorCode(emailWithoutSpace, authCodeWithoutSpace)
+        clientSideErrorCode?.let {
+            return BaseResponse.Failure(errorCode = it, errorMessage = errorCodeMapper.mapCodeToString(it))
+        }
+
+        val response = repository.checkAuthCode(emailWithoutSpace, authCode)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
+    }
+
+    private fun getClientSideErrorCode(email : String, authCode : String) : Int? {
+        return if (!isEmailFormat(email)) {
+            INVALID_EMAIL_FORMAT
+        } else if (authCode.length != 4) {
+            INVALID_AUTH_CODE_FORMAT
+        } else {
+            null
+        }
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -2,20 +2,25 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseIssueAuthCode @Inject constructor(
-    private val repository: LoginRepository
+    private val repository: LoginRepository,
+    @AuthCodeErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
     suspend operator fun invoke(email : String) : BaseResponse<Nothing> {
         val emailWithoutSpace = email.removeWhiteSpace()
         if (!isEmailFormat(emailWithoutSpace)) {
-            return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
+            val errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT
+            return BaseResponse.Failure(errorCode = errorCode, errorMessage = errorCodeMapper.mapCodeToString(errorCode))
         }
 
-        return repository.issueAuthCode(emailWithoutSpace)
+        val response = repository.issueAuthCode(emailWithoutSpace)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseLogin.kt
@@ -3,25 +3,37 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.domain.login.di.LoginErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseLogin @Inject constructor(
-    private val repository : LoginRepository
+    private val repository : LoginRepository,
+    @LoginErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
     suspend operator fun invoke(email : String, password : String) : BaseResponse<Tokens> {
         val emailWithoutSpace = email.removeWhiteSpace()
         val passwordWithoutSpace = password.removeWhiteSpace()
 
-        if (emailWithoutSpace.isEmpty() || passwordWithoutSpace.isEmpty()) {
-            return BaseResponse.Failure(errorCode = LoginErrorCodes.INPUT_EMAIL_AND_PASSWORD, errorMessage = "이메일/비밀번호를 입력해 주세요.")
-        }
-        if (!isEmailFormat(emailWithoutSpace)) {
-            return BaseResponse.Failure(errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT, errorMessage = "이메일 형식으로 입력해 주세요.")
+        val clientCheckableErrorCode = getClientSideErrorCode(emailWithoutSpace, passwordWithoutSpace)
+        clientCheckableErrorCode?.let {
+            return BaseResponse.Failure(errorCode = it, errorMessage = errorCodeMapper.mapCodeToString(it))
         }
 
-        return repository.emailLogin(emailWithoutSpace, passwordWithoutSpace)
+        val response = repository.emailLogin(emailWithoutSpace, passwordWithoutSpace)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
+    }
+
+    private fun getClientSideErrorCode(email : String, password : String) : Int? {
+        return if (email.isEmpty() || password.isEmpty()) {
+            LoginErrorCodes.EMPTY_EMAIL_OR_PASSWORD
+        } else if (!isEmailFormat(email)) {
+            LoginErrorCodes.INVALID_EMAIL_FORMAT
+        } else {
+            null
+        }
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseSignup.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseSignup.kt
@@ -2,16 +2,20 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.domain.login.di.SignupErrorCodeMapperProvide
 import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
 import javax.inject.Inject
 
 class UseCaseSignup @Inject constructor(
-    private val repository: LoginRepository
+    private val repository: LoginRepository,
+    @SignupErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
     suspend operator fun invoke(email : String, password : String) : BaseResponse<String> {
         val emailWithoutSpace = email.removeWhiteSpace()
         val passwordWithoutSpace = password.removeWhiteSpace()
 
-        return repository.emailSignup(emailWithoutSpace, passwordWithoutSpace)
+        val response = repository.emailSignup(emailWithoutSpace, passwordWithoutSpace)
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseWithdrawal.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseWithdrawal.kt
@@ -2,12 +2,16 @@ package com.strayalphaca.travel_diary.domain.login.use_case
 
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.travel_diary.domain.login.di.WithdrawalErrorCodeMapperProvide
 import javax.inject.Inject
 
 class UseCaseWithdrawal @Inject constructor(
-    private val repository : LoginRepository
+    private val repository : LoginRepository,
+    @WithdrawalErrorCodeMapperProvide private val errorCodeMapper : ErrorCodeMapper
 ) {
     suspend operator fun invoke() : BaseResponse<Nothing> {
-        return repository.withdrawal()
+        val response = repository.withdrawal()
+        return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/DefaultErrorCodeMapper.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/DefaultErrorCodeMapper.kt
@@ -1,0 +1,29 @@
+package com.strayalphaca.presentation.models.error_code_mapper
+
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.R
+
+class DefaultErrorCodeMapper constructor(
+    private val specificDomainErrorCodeMapper: ErrorCodeMapper?,
+    private val context : Context
+): ErrorCodeMapper {
+    private val defaultErrorCodeSet = setOf(500, 404)
+
+    override fun mapCodeToString(errorCode: Int): String {
+        return if (errorCode in defaultErrorCodeSet) {
+            mapDefaultCodeToString(errorCode = errorCode)
+        } else {
+            specificDomainErrorCodeMapper?.mapCodeToString(errorCode = errorCode)
+                ?: context.getString(R.string.unknown_error)
+        }
+    }
+
+    private fun mapDefaultCodeToString(errorCode: Int) : String {
+        return when(errorCode) {
+            404 -> context.getString(R.string.unknown_error)
+            500 -> context.getString(R.string.server_side_error)
+            else -> context.getString(R.string.unknown_error)
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/diary/DiaryErrorCodeMapper.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/diary/DiaryErrorCodeMapper.kt
@@ -1,0 +1,22 @@
+package com.strayalphaca.presentation.models.error_code_mapper.diary
+
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.R
+import com.strayalphaca.travel_diary.diary.model.DiaryErrorCodes.EMPTY_ARGUMENT_DIARY_CONTENT
+
+class DiaryErrorCodeMapper constructor(
+    private val context : Context
+) : ErrorCodeMapper {
+    override fun mapCodeToString(errorCode: Int): String {
+        return when(errorCode) {
+            EMPTY_ARGUMENT_DIARY_CONTENT -> {
+                context.getString(R.string.diary_error_empty_diary_content)
+            }
+            else -> {
+                context.getString(R.string.unknown_error)
+            }
+        }
+    }
+
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/AuthCodeErrorCodeMapper.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/AuthCodeErrorCodeMapper.kt
@@ -1,0 +1,31 @@
+package com.strayalphaca.presentation.models.error_code_mapper.login
+
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.R
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_AUTH_CODE_FORMAT
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_EMAIL_FORMAT
+
+class AuthCodeErrorCodeMapper constructor(
+    private val context : Context
+) : ErrorCodeMapper {
+    override fun mapCodeToString(errorCode: Int): String {
+        return when (errorCode) {
+            INVALID_EMAIL_FORMAT -> {
+                context.getString(R.string.login_error_invalid_email_format)
+            }
+            INVALID_AUTH_CODE_FORMAT -> {
+                context.getString(R.string.login_error_invalid_auth_code_format)
+            }
+            400 -> {
+                context.getString(R.string.login_error_invalid_auth_code)
+            }
+            409 -> {
+                context.getString(R.string.login_error_exist_email)
+            }
+            else -> {
+                context.getString(R.string.unknown_error)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/LoginErrorCodeMapper.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/LoginErrorCodeMapper.kt
@@ -1,0 +1,28 @@
+package com.strayalphaca.presentation.models.error_code_mapper.login
+
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.R
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.EMPTY_EMAIL_OR_PASSWORD
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_EMAIL_FORMAT
+
+class LoginErrorCodeMapper constructor(
+    private val context : Context
+) : ErrorCodeMapper {
+    override fun mapCodeToString(errorCode: Int): String {
+        return when(errorCode) {
+            EMPTY_EMAIL_OR_PASSWORD -> {
+                context.getString(R.string.login_error_empty_email_or_password)
+            }
+            INVALID_EMAIL_FORMAT -> {
+                context.getString(R.string.login_error_invalid_email_format)
+            }
+            409 -> {
+                context.getString(R.string.login_error_non_exist_email_or_password)
+            }
+            else -> {
+                context.getString(R.string.unknown_error)
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/SignupErrorCodeMapper.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/error_code_mapper/login/SignupErrorCodeMapper.kt
@@ -1,0 +1,25 @@
+package com.strayalphaca.presentation.models.error_code_mapper.login
+
+import android.content.Context
+import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
+import com.strayalphaca.presentation.R
+import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.EMPTY_PASSWORD
+
+class SignupErrorCodeMapper constructor(
+    private val context : Context
+) : ErrorCodeMapper {
+    override fun mapCodeToString(errorCode: Int): String {
+        return when(errorCode) {
+            409 -> {
+                context.getString(R.string.login_error_exist_email)
+            }
+            EMPTY_PASSWORD -> {
+                context.getString(R.string.login_error_empty_password)
+            }
+            else -> {
+                context.getString(R.string.unknown_error)
+            }
+        }
+    }
+
+}

--- a/presentation/src/main/res/values/strings_error_code.xml
+++ b/presentation/src/main/res/values/strings_error_code.xml
@@ -3,7 +3,13 @@
     <string name="server_side_error">통신이 원활하지 않습니다.\n잠시 후 다시 시도해주세요.</string>
     <string name="unknown_error">알수없는 에러가 발생했습니다.\n잠시 후 다시 시도해주세요.</string>
 
-    <string name="login_empty_email_or_password">비밀번호와 이메일을 모두 입력해주세요.</string>
-    <string name="login_invalid_email_format">이메일 형식을 맞춰 입력해주세요.</string>
-    <string name="login_non_exist_email_or_password">존재하지 않은 이메일/비밀번호입니다.</string>
+    <string name="login_error_empty_email_or_password">비밀번호와 이메일을 모두 입력해주세요.</string>
+    <string name="login_error_invalid_email_format">이메일 형식을 맞춰 입력해주세요.</string>
+    <string name="login_error_non_exist_email_or_password">존재하지 않은 이메일/비밀번호입니다.</string>
+
+    <string name="login_error_exist_email">이미 가입된 이메일입니다.</string>
+
+    <string name="login_error_empty_password">비밀번호를 입력해 주세요.</string>
+    <string name="login_error_invalid_auth_code_format">인증번호 4자리를 입력해 주세요.</string>
+    <string name="login_error_invalid_auth_code">인증번호가 일치하지 않습니다.</string>
 </resources>

--- a/presentation/src/main/res/values/strings_error_code.xml
+++ b/presentation/src/main/res/values/strings_error_code.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="server_side_error">통신이 원활하지 않습니다.\n잠시 후 다시 시도해주세요.</string>
+    <string name="unknown_error">알수없는 에러가 발생했습니다.\n잠시 후 다시 시도해주세요.</string>
+
+    <string name="login_empty_email_or_password">비밀번호와 이메일을 모두 입력해주세요.</string>
+    <string name="login_invalid_email_format">이메일 형식을 맞춰 입력해주세요.</string>
+    <string name="login_non_exist_email_or_password">존재하지 않은 이메일/비밀번호입니다.</string>
+</resources>

--- a/presentation/src/main/res/values/strings_error_code.xml
+++ b/presentation/src/main/res/values/strings_error_code.xml
@@ -12,4 +12,7 @@
     <string name="login_error_empty_password">비밀번호를 입력해 주세요.</string>
     <string name="login_error_invalid_auth_code_format">인증번호 4자리를 입력해 주세요.</string>
     <string name="login_error_invalid_auth_code">인증번호가 일치하지 않습니다.</string>
+
+    <string name="diary_error_empty_diary_content">내용을 입력해주세요.</string>
+    <string name="diary_error_exist_today_diary">오늘은 이미 일지를 작성했어요.</string>
 </resources>


### PR DESCRIPTION
각 UseCase에서 발생 가능한 에러에 대해 에러 코드를 string리소스를 사용한 문자열로 변환시키는 ErrorCodeMapper 생성
- core:domain에 ErrorCodeMapper 인터페이스 정의
- 각 useCase에서 사용하는 각 ErrorCodeMapper들의 구현체는 각각 다르므로, 해당 구현체를 주입하기 위한 Qualifier 어노테이션 클래스를 useCase가 정의된 모듈의 di 패키지에 선언
  - 구현체들은 presentation 모듈 내 정의
  - 실제 주입부는 app 모듈의 di 패키지에서 수행

굳이 domain 레이어에서 인터페이스를 정의하고, 이를 presentation 레이어에서 구현하는 이유는 아래와 같음
- domain 레이어에서 구현체를 정의하지 못하는 이유는, domain 레이어는 순수 kotlin 모듈로 context와 같은 안드로이드 종속적인 요소를 사용하지 못하기 때문에 string.xml에 정의된 문자열 리소스에 바로 접근할 수 없기 때문이다.
- presentation 레이어에서 인터페이스를 정의하지 않고 domain 레이어에서 인퍼테이스를 정의한 이유는, domain 레이어에서 정의한 useCase에서 해당 UseCase의 에러 케이스를 처리하기 때문이다.
  - 빈 문자열이나 이메일 형식 체크와 같은 클라이언트에서 감지 가능한 에러들은 UseCase에서 감지하여 BaseResponse.Failure를 리턴한다.
  - 서버측에서 발생한 에러의 경우, repository에서 전달받은 BaseResponse.Failure에서 errorCode에 맞는 에러 메세지로 매핑하여 리턴한다.
  - 이를 통해 presentation 레이어의 viewModel에서 입력값에 대한 검증 작업을 수행하지 않을 수 있다. (useCase 내부에서 처리하게 되므로)