### PR TITLE
Fix push alarm

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="traily" android:host="notification" />
+            </intent-filter>
         </activity>
 
         <receiver android:name="com.strayalphaca.presentation.alarm.TrailyAlarmReceiver" android:exported="true">

--- a/app/src/main/java/com/strayalphaca/travel_diary/RootActivity.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/RootActivity.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -29,26 +30,26 @@ import com.strayalphaca.presentation.screens.video.VideoContainer
 import com.strayalphaca.presentation.screens.video.VideoViewModel
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import com.strayalphaca.presentation.utils.collectAsEffect
-import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import dagger.hilt.android.AndroidEntryPoint
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class RootActivity : ComponentActivity() {
 
-    @Inject lateinit var authRepository: AuthRepository
+    private val viewModel : RootViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        intent?.data?.let { uri ->
+            viewModel.handleLink(uri.toString())
+        }
 
         setContent {
             TravelDiaryTheme {
                 val navHostController = rememberNavController()
 
-                authRepository.invalidRefreshToken().collectAsEffect {
-                    if (it) {
-                        navHostController.navigateToIntroTop()
-                    }
+                viewModel.invalidRefreshToken.collectAsEffect { tokenErrorOccur ->
+                    if (tokenErrorOccur) navHostController.navigateToIntroTop()
                 }
 
                 RootNavHost(navController = navHostController)

--- a/app/src/main/java/com/strayalphaca/travel_diary/RootViewModel.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/RootViewModel.kt
@@ -1,0 +1,23 @@
+package com.strayalphaca.travel_diary
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.strayalphaca.presentation.models.deeplink_handler.NotificationDeepLinkHandler
+import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RootViewModel @Inject constructor(
+    authRepository: AuthRepository,
+    private val deepLinkHandler: NotificationDeepLinkHandler
+) : ViewModel() {
+    val invalidRefreshToken = authRepository.invalidRefreshToken()
+
+    fun handleLink(deepLink : String) {
+        viewModelScope.launch {
+            deepLinkHandler.setDeepLinkEvent(deepLink)
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/alarm/NotificationManager.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/alarm/NotificationManager.kt
@@ -1,16 +1,14 @@
 package com.strayalphaca.presentation.alarm
 
-import android.app.Activity
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
-import android.app.TaskStackBuilder
 import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.net.toUri
 import com.strayalphaca.presentation.models.NotificationChannelInfo
-import kotlin.reflect.KClass
 
 class NotificationManager {
 
@@ -34,7 +32,6 @@ class NotificationManager {
         channelId : String, iconResourceId : Int,
         title : String, text : String,
         notificationId : Int,
-        target : KClass<out Activity>,
         deepLink : String ?= null
     ) {
         val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
@@ -44,7 +41,7 @@ class NotificationManager {
             setContentTitle(title)
             setContentText(text)
             deepLink?.let { link ->
-                setContentIntent(createPendingIntent(context, target, link))
+                setContentIntent(createPendingIntent(context, link))
             }
             setAutoCancel(true)
         }.build()
@@ -52,12 +49,11 @@ class NotificationManager {
         notificationManager.notify(notificationId, builder)
     }
 
-    private fun createPendingIntent(context : Context, target : KClass<out Activity>, deepLink : String) : PendingIntent? {
-        val resultIntent = Intent(context, target.java).apply { putExtra("deepLink", deepLink) }
-        val resultPendingIntent : PendingIntent? = TaskStackBuilder.create(context).run {
-            addNextIntentWithParentStack(resultIntent)
-            getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE)
+    private fun createPendingIntent(context : Context, deepLink : String): PendingIntent? {
+        val routeIntent = Intent(Intent.ACTION_VIEW, deepLink.toUri()).apply {
+            flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
         }
-        return resultPendingIntent
+        val flags = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        return PendingIntent.getActivity(context, 0, routeIntent, flags)
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/alarm/TrailyAlarmReceiver.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/alarm/TrailyAlarmReceiver.kt
@@ -1,6 +1,5 @@
 package com.strayalphaca.presentation.alarm
 
-import android.app.Activity
 import android.app.AlarmManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -18,12 +17,10 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.reflect.KClass
 
 @AndroidEntryPoint
 class TrailyAlarmReceiver : BroadcastReceiver() {
     private val notificationManager = NotificationManager()
-    @Inject lateinit var rootActivity : KClass<out Activity>
     @Inject lateinit var useCaseGetAlarmInfo: UseCaseGetAlarmInfo
     @Inject lateinit var trailyAlarmManager: TrailyAlarmManager
 
@@ -39,7 +36,6 @@ class TrailyAlarmReceiver : BroadcastReceiver() {
                     title = context.getString(R.string.notification_title),
                     text = context.getString(R.string.notification_text),
                     notificationId = NOTIFICATION_ID,
-                    target = rootActivity,
                     deepLink = intent.getStringExtra("deepLink")
                 )
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/Route.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/Route.kt
@@ -3,20 +3,23 @@ package com.strayalphaca.presentation.models
 import com.strayalphaca.presentation.R
 
 sealed class Route(val uri : String?, val screenNameId : Int) {
-    object Calendar : Route(uri = "calendar", screenNameId = R.string.calendar_page)
-    object Map : Route(uri = "map", screenNameId = R.string.map_page)
-    object DiaryWrite : Route(uri = "diary_write", screenNameId = R.string.diary_write_page)
+    object Calendar : Route(uri = "${scheme}://${host}?calendar", screenNameId = R.string.calendar_page)
+    object Map : Route(uri = "${scheme}://${host}?map", screenNameId = R.string.map_page)
+    object DiaryWrite : Route(uri = "${scheme}://${host}?diary_write", screenNameId = R.string.diary_write_page)
     object Null : Route(uri = null, screenNameId = R.string.not_select)
     companion object {
         val pushAlarmTargetList = listOf(
             Calendar, Map, DiaryWrite, Null
         )
 
+        private const val host = "notification"
+        private const val scheme = "traily"
+
         fun getInstanceByUriString(uriString : String?) : Route {
             return when (uriString) {
-                "calendar" -> Calendar
-                "map" -> Map
-                "diary_write" -> DiaryWrite
+                Calendar.uri -> Calendar
+                Map.uri -> Map
+                DiaryWrite.uri -> DiaryWrite
                 else -> Null
             }
         }

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/Route.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/Route.kt
@@ -4,13 +4,14 @@ import com.strayalphaca.presentation.R
 
 sealed class Route(val uri : String?, val screenNameId : Int) {
     object Calendar : Route(uri = "${scheme}://${host}?calendar", screenNameId = R.string.calendar_page)
-    object Map : Route(uri = "${scheme}://${host}?map", screenNameId = R.string.map_page)
     object DiaryWrite : Route(uri = "${scheme}://${host}?diary_write", screenNameId = R.string.diary_write_page)
     object Null : Route(uri = null, screenNameId = R.string.not_select)
     companion object {
-        val pushAlarmTargetList = listOf(
-            Calendar, Map, DiaryWrite, Null
-        )
+        val pushAlarmTargetList: List<Route> by lazy {
+            listOf(
+                Calendar, DiaryWrite, Null
+            )
+        }
 
         private const val host = "notification"
         private const val scheme = "traily"
@@ -18,7 +19,6 @@ sealed class Route(val uri : String?, val screenNameId : Int) {
         fun getInstanceByUriString(uriString : String?) : Route {
             return when (uriString) {
                 Calendar.uri -> Calendar
-                Map.uri -> Map
                 DiaryWrite.uri -> DiaryWrite
                 else -> Null
             }

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/deeplink_handler/NotificationDeepLinkHandler.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/deeplink_handler/NotificationDeepLinkHandler.kt
@@ -1,0 +1,25 @@
+package com.strayalphaca.presentation.models.deeplink_handler
+
+import com.strayalphaca.presentation.models.Route
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class NotificationDeepLinkHandler @Inject constructor() {
+    private val _deepLinkEvent = MutableEventFlow<DeepLinkEvent>()
+    val deepLinkEvent = _deepLinkEvent.asEventFlow()
+
+    suspend fun setDeepLinkEvent(deepLink : String) {
+        when(deepLink) {
+            Route.DiaryWrite.uri -> {
+                _deepLinkEvent.emit(DeepLinkEvent.WRITE_DIARY)
+            }
+        }
+    }
+}
+
+enum class DeepLinkEvent {
+    WRITE_DIARY
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/event_flow/EventFlow.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/event_flow/EventFlow.kt
@@ -1,0 +1,48 @@
+package com.strayalphaca.presentation.models.event_flow
+
+import kotlinx.coroutines.InternalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import java.util.concurrent.atomic.AtomicBoolean
+
+interface EventFlow<out T> : Flow<T> {
+    companion object {
+        const val DEFAULT_REPLAY: Int = 1
+    }
+}
+
+interface MutableEventFlow<T> : EventFlow<T>, FlowCollector<T>
+
+@Suppress("FunctionName")
+fun <T> MutableEventFlow(
+    replay: Int = EventFlow.DEFAULT_REPLAY
+): MutableEventFlow<T> = EventFlowImpl(replay)
+
+fun <T> MutableEventFlow<T>.asEventFlow(): EventFlow<T> = ReadOnlyEventFlow(this)
+
+private class ReadOnlyEventFlow<T>(flow: EventFlow<T>) : EventFlow<T> by flow
+
+private class EventFlowImpl<T>(
+    replay: Int
+) : MutableEventFlow<T> {
+
+    private val flow: MutableSharedFlow<EventFlowSlot<T>> = MutableSharedFlow(replay = replay)
+
+    @InternalCoroutinesApi
+    override suspend fun collect(collector: FlowCollector<T>) = flow
+        .collect { slot ->
+            if (!slot.markConsumed()) {
+                collector.emit(slot.value)
+            }
+        }
+
+    override suspend fun emit(value: T) {
+        flow.emit(EventFlowSlot(value))
+    }
+}
+
+private class EventFlowSlot<T>(val value: T) {
+    private val consumed: AtomicBoolean = AtomicBoolean(false)
+    fun markConsumed(): Boolean = consumed.getAndSet(true)
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
@@ -6,6 +6,8 @@ import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
 import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseCheckWrittenOnToday
 import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseGetCalendarDiary
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.deeplink_handler.DeepLinkEvent
+import com.strayalphaca.presentation.models.deeplink_handler.NotificationDeepLinkHandler
 import com.strayalphaca.presentation.utils.collectLatestInScope
 import com.strayalphaca.travel_diary.domain.calendar.utils.fillEmptyCellToCalendarData
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -18,7 +20,8 @@ import javax.inject.Inject
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
     private val useCaseGetCalendarDiary: UseCaseGetCalendarDiary,
-    private val useCaseCheckWrittenOnToday: UseCaseCheckWrittenOnToday
+    private val useCaseCheckWrittenOnToday: UseCaseCheckWrittenOnToday,
+    deepLinkHandler: NotificationDeepLinkHandler
 ) : ViewModel() {
     private val events = Channel<CalendarViewEvent>()
     val state : StateFlow<CalendarScreenState> = events.receiveAsFlow()
@@ -42,6 +45,11 @@ class CalendarViewModel @Inject constructor(
             events.send(CalendarViewEvent.SuccessLoadDiaryData(it.year, it.month, diaryList))
         }
 
+        deepLinkHandler.deepLinkEvent.collectLatestInScope(viewModelScope) {
+            if (it == DeepLinkEvent.WRITE_DIARY) {
+                checkTodayWrite()
+            }
+        }
     }
 
     fun tryGetDiaryData(year : Int, month : Int) {


### PR DESCRIPTION
- 단일 이벤트 처리에 SharedFlow 대신 사용할 EventFlow 정의
- 생성된 Notification 클릭시 화면 호출 로직을 Intent(context, class) 방식에서 ACTION_VIEW를 사용하는 방식으로 변경
  - menifest에 ACTION_VIEW에 대한 intent-filter 정의
- notification 클릭시 딥링크 데이터를 관리하는 NotificationDeepLinkeHandler 정의
  - RootViewModel에서 딥링크 정보를 DeepLinkHandler에 전달
  - CalendarViewModel에서 딥링크 정보를 collect하여 딥링크에 따라 적합한 행동 수행