### PR TITLE
Fix map

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
@@ -18,9 +17,10 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.strayalphaca.presentation.ui.theme.Tape
+import com.strayalphaca.presentation.utils.pxToDp
 
 @Composable
-fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : String?, id : Int) {
+fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : String?, id : Int, widthPx : Int) {
     Surface(
         modifier = modifier
             .padding(2.dp)
@@ -31,7 +31,7 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(2.dp)
+                .padding((widthPx * 0.05f).toInt().pxToDp())
         ) {
             if (thumbnailUrl == null) {
                 Box(
@@ -44,10 +44,12 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .aspectRatio(0.8f)
                         .background(Tape)
                 ) {
                     AsyncImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f),
                         model = thumbnailUrl,
                         contentDescription = "thumbnail_image",
                         contentScale = ContentScale.Crop
@@ -56,7 +58,10 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
 
             }
 
-            Spacer(modifier = Modifier.height(10.dp))
+            Spacer(modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(3f)
+            )
         }
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
@@ -41,7 +41,7 @@ fun CityPickerDialog(
     val lazyColumnListState = rememberLazyGridState()
 
     TapeDialog(onDismissRequest = onDismissRequest) {
-        Column(modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp)) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Text(
                 modifier = Modifier.padding(vertical = 16.dp, horizontal = 28.dp),
                 text = stringResource(id = R.string.select_location),
@@ -50,7 +50,7 @@ fun CityPickerDialog(
             )
 
             LazyVerticalGrid(
-                modifier = Modifier.padding(horizontal = 28.dp).weight(1f),
+                modifier = Modifier.padding(horizontal = 28.dp).heightIn(max = 480.dp),
                 columns = GridCells.Adaptive(minSize = 120.dp),
                 state = lazyColumnListState
             ) {

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
@@ -5,10 +5,12 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
@@ -36,9 +38,10 @@ fun CityPickerDialog(
     val cityList : List<City> by remember {
         mutableStateOf(City.getSameGroupCityList(cityGroupId))
     }
+    val lazyColumnListState = rememberLazyGridState()
 
     TapeDialog(onDismissRequest = onDismissRequest) {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.fillMaxWidth().heightIn(max = 480.dp)) {
             Text(
                 modifier = Modifier.padding(vertical = 16.dp, horizontal = 28.dp),
                 text = stringResource(id = R.string.select_location),
@@ -47,8 +50,9 @@ fun CityPickerDialog(
             )
 
             LazyVerticalGrid(
-                modifier = Modifier.padding(horizontal = 28.dp),
-                columns = GridCells.Adaptive(minSize = 120.dp)
+                modifier = Modifier.padding(horizontal = 28.dp).weight(1f),
+                columns = GridCells.Adaptive(minSize = 120.dp),
+                state = lazyColumnListState
             ) {
                 items(cityList) { city ->
                     Text(

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CityPickerDialog.kt
@@ -36,7 +36,7 @@ fun CityPickerDialog(
 ) {
     var selectedLocation : Int? by remember { mutableStateOf(currentSelectedLocationId) }
     val cityList : List<City> by remember {
-        mutableStateOf(City.getSameGroupCityList(cityGroupId))
+        mutableStateOf(City.getSameGroupCityList(cityGroupId).sortedBy { it.name })
     }
     val lazyColumnListState = rememberLazyGridState()
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/traily_map/TrailyMap.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/traily_map/TrailyMap.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -47,6 +48,9 @@ fun TrailyMap(
     var imageSize by remember { mutableStateOf(IntSize.Zero) }
     var boxRatio by remember { mutableStateOf(2f) }
     val imageRatio = getMapImageRatioById(locationId)
+    val diaryWidth by remember(imageSize) {
+        derivedStateOf { (imageSize.width * 0.15f).toInt() }
+    }
 
     Box(
         modifier
@@ -87,17 +91,20 @@ fun TrailyMap(
                 locationDiaryList.forEach { locationDiary ->
                     DiaryInMap(
                         modifier = Modifier
-                            .width(40.dp)
+                            .width(
+                                diaryWidth.pxToDp()
+                            )
                             .offset(
                                 x = getOffsetX(
                                     locationDiary.location,
                                     imageSize.width
-                                ).pxToDp() - 20.dp,
+                                ).pxToDp() - (diaryWidth / 2).pxToDp(),
                                 y = getOffsetY(locationDiary.location, imageSize.height).pxToDp()
                             ),
                         onClick = onClickDiary,
                         thumbnailUrl = locationDiary.thumbnailUri,
-                        id = locationDiary.location.id.id
+                        id = locationDiary.location.id.id,
+                        widthPx = diaryWidth
                     )
                 }
             }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/DiaryListScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary_list/DiaryListScreen.kt
@@ -181,7 +181,7 @@ fun DiaryListScreen(
                         if (diaryList.isNotEmpty()) {
                             LazyVerticalGrid(
                                 state = lazyColumnListState,
-                                columns = GridCells.Fixed(2),
+                                columns = GridCells.Adaptive(minSize = 140.dp),
                                 contentPadding = PaddingValues(top = 16.dp, bottom = 16.dp),
                                 content = {
                                     items(
@@ -199,7 +199,7 @@ fun DiaryListScreen(
                                         )
                                     }
 
-                                    item(span = { GridItemSpan(2)}) {
+                                    item(span = { GridItemSpan( this.maxLineSpan )}) {
                                         when (pagingState) {
                                             SimplePagingState.LAST -> {
                                                 EndOfPageView(


### PR DESCRIPTION
- 지도 화면에서 표시되는 DiaryUI의 크기가 화면 크기와 관계없이 항상 너비 40dp, 높이 60dp로 고정했던 부분을 지도 이미지 크기에 비례하도록 수정
- 지역별 작성일지 목록 조회 화면에서 아래 항목들을 수정
  - 도시 선택 다이얼로그의 도시 선택 부분을 스크롤 가능하도록 수정 및 다이얼로그의 최대 높이 지정
  - 도시명이 가나다 오름차순으로 표기되도록 수정
  - 가로 화면크기가 클 경우 더 많은 일지가 보여지도록 LazyVerticalGrid의 column설정값을 Fixed에서 Adaptive로 변경
