### PR TITLE
Fix login

### DIFF
--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
@@ -1,5 +1,6 @@
 package com.strayalphaca.travel_diary.data.login.api
 
+import com.strayalphaca.travel_diary.data.login.model.ChangePasswordRequestBody
 import com.strayalphaca.travel_diary.data.login.model.IssueAuthCodeBody
 import com.strayalphaca.travel_diary.data.login.model.LoginRequestBody
 import com.strayalphaca.travel_diary.data.login.model.SignUpRequestBody
@@ -9,6 +10,7 @@ import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -27,4 +29,7 @@ interface LoginApi {
 
     @DELETE("users")
     suspend fun withDraw() : Response<Unit>
+
+    @PATCH("auth/password")
+    suspend fun changePassword(@Body params : ChangePasswordRequestBody) : Response<Unit>
 }

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/api/LoginApi.kt
@@ -16,7 +16,7 @@ import retrofit2.http.Query
 
 interface LoginApi {
     @GET("auth/code")
-    suspend fun checkAuthCode(@Query("email") email : String, @Query("code") code : String) : Response<Unit>
+    suspend fun checkAuthCode(@Query("email") email : String, @Query("code") code : String, @Query("type") type : String) : Response<Unit>
 
     @POST("auth/code")
     suspend fun issueAuthCode(@Body params : IssueAuthCodeBody) : Response<Unit>

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/RequestBody.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/RequestBody.kt
@@ -1,6 +1,6 @@
 package com.strayalphaca.travel_diary.data.login.model
 
-data class IssueAuthCodeBody(val email : String)
+data class IssueAuthCodeBody(val email : String, val type : String)
 
 data class SignUpRequestBody(val email : String, val password : String)
 

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/RequestBody.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/model/RequestBody.kt
@@ -5,3 +5,5 @@ data class IssueAuthCodeBody(val email : String)
 data class SignUpRequestBody(val email : String, val password : String)
 
 data class LoginRequestBody(val email : String, val password : String)
+
+data class ChangePasswordRequestBody(val prevPassword : String, val newPassword : String)

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/LoginRepositoryImpl.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/LoginRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.strayalphaca.travel_diary.core.data.utils.mapBaseResponse
 import com.strayalphaca.travel_diary.data.login.utils.tokenDtoToToken
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,11 +24,11 @@ class LoginRepositoryImpl @Inject constructor(
         return loginDataSource.postSignup()
     }
 
-    override suspend fun checkAuthCode(email : String, authCode: String): BaseResponse<Nothing> {
+    override suspend fun checkAuthCode(email : String, authCode: String, type : AuthCodeCaseType): BaseResponse<Nothing> {
         return loginDataSource.getAuthCode(email, authCode)
     }
 
-    override suspend fun issueAuthCode(email : String): BaseResponse<Nothing> {
+    override suspend fun issueAuthCode(email : String, type : AuthCodeCaseType): BaseResponse<Nothing> {
         return loginDataSource.postAuthCode(email)
     }
 

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
@@ -10,6 +10,7 @@ import com.strayalphaca.travel_diary.data.login.utils.tokenDtoToToken
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.data.login.model.ChangePasswordRequestBody
 import com.strayalphaca.travel_diary.data.login.utils.extractIdFromSignupResponse
 import retrofit2.Retrofit
 import javax.inject.Inject
@@ -55,11 +56,12 @@ class RemoteLoginRepository @Inject constructor(
         return BaseResponse.EmptySuccess
     }
 
-    // todo - 비밀번호 변경 api 구현시 연동
     override suspend fun changePassword(
         prevPassword: String,
         newPassword: String
     ): BaseResponse<Nothing> {
-        return BaseResponse.EmptySuccess
+        val requestBody = ChangePasswordRequestBody(prevPassword = prevPassword, newPassword = newPassword)
+        val response = loginRetrofit.changePassword(requestBody)
+        return voidResponseToBaseResponse(response)
     }
 }

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/repository_impl/RemoteLoginRepository.kt
@@ -12,6 +12,7 @@ import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.data.login.model.ChangePasswordRequestBody
 import com.strayalphaca.travel_diary.data.login.utils.extractIdFromSignupResponse
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import retrofit2.Retrofit
 import javax.inject.Inject
 
@@ -36,13 +37,13 @@ class RemoteLoginRepository @Inject constructor(
         )
     }
 
-    override suspend fun checkAuthCode(email: String, authCode: String): BaseResponse<Nothing> {
-        val response = loginRetrofit.checkAuthCode(email, authCode)
+    override suspend fun checkAuthCode(email: String, authCode: String, type : AuthCodeCaseType): BaseResponse<Nothing> {
+        val response = loginRetrofit.checkAuthCode(email, authCode, type.name)
         return voidResponseToBaseResponse(response)
     }
 
-    override suspend fun issueAuthCode(email: String): BaseResponse<Nothing> {
-        val response = loginRetrofit.issueAuthCode(IssueAuthCodeBody(email))
+    override suspend fun issueAuthCode(email: String, type : AuthCodeCaseType): BaseResponse<Nothing> {
+        val response = loginRetrofit.issueAuthCode(IssueAuthCodeBody(email, type.name))
         return voidResponseToBaseResponse(response)
     }
 

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/AuthCodeCaseType.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/model/AuthCodeCaseType.kt
@@ -1,0 +1,5 @@
+package com.strayalphaca.travel_diary.domain.login.model
+
+enum class AuthCodeCaseType {
+    REGISTER, RESET_PASSWORD
+}

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/repository/LoginRepository.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/repository/LoginRepository.kt
@@ -2,12 +2,13 @@ package com.strayalphaca.travel_diary.domain.login.repository
 
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 
 interface LoginRepository {
     suspend fun emailLogin(email : String, password : String) : BaseResponse<Tokens>
     suspend fun emailSignup(email : String, password : String) : BaseResponse<String>
-    suspend fun checkAuthCode(email : String, authCode : String) : BaseResponse<Nothing>
-    suspend fun issueAuthCode(email : String) : BaseResponse<Nothing>
+    suspend fun checkAuthCode(email : String, authCode : String, type : AuthCodeCaseType) : BaseResponse<Nothing>
+    suspend fun issueAuthCode(email : String, type : AuthCodeCaseType) : BaseResponse<Nothing>
     suspend fun withdrawal() : BaseResponse<Nothing>
     suspend fun issueRandomPasswordToEmail(email : String) : BaseResponse<Nothing>
     suspend fun changePassword(prevPassword : String, newPassword : String) : BaseResponse<Nothing>

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseCheckAuthCode.kt
@@ -4,6 +4,7 @@ import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
 import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_AUTH_CODE_FORMAT
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes.INVALID_EMAIL_FORMAT
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
@@ -14,7 +15,7 @@ class UseCaseCheckAuthCode @Inject constructor(
     private val repository: LoginRepository,
     @AuthCodeErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
-    suspend operator fun invoke(email : String, authCode : String): BaseResponse<Nothing> {
+    suspend operator fun invoke(email : String, authCode : String, type : AuthCodeCaseType = AuthCodeCaseType.REGISTER): BaseResponse<Nothing> {
         val emailWithoutSpace = email.removeWhiteSpace()
         val authCodeWithoutSpace = authCode.removeWhiteSpace()
 
@@ -23,7 +24,7 @@ class UseCaseCheckAuthCode @Inject constructor(
             return BaseResponse.Failure(errorCode = it, errorMessage = errorCodeMapper.mapCodeToString(it))
         }
 
-        val response = repository.checkAuthCode(emailWithoutSpace, authCode)
+        val response = repository.checkAuthCode(emailWithoutSpace, authCode, type)
         return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 

--- a/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
+++ b/domain/login/src/main/java/com/strayalphaca/travel_diary/domain/login/use_case/UseCaseIssueAuthCode.kt
@@ -4,6 +4,7 @@ import com.strayalphaca.travel_diary.domain.login.repository.LoginRepository
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalpaca.travel_diary.core.domain.model.ErrorCodeMapper
 import com.strayalphaca.travel_diary.domain.login.di.AuthCodeErrorCodeMapperProvide
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import com.strayalphaca.travel_diary.domain.login.model.LoginErrorCodes
 import com.strayalphaca.travel_diary.domain.login.utils.isEmailFormat
 import com.strayalphaca.travel_diary.domain.login.utils.removeWhiteSpace
@@ -13,14 +14,14 @@ class UseCaseIssueAuthCode @Inject constructor(
     private val repository: LoginRepository,
     @AuthCodeErrorCodeMapperProvide private val errorCodeMapper: ErrorCodeMapper
 ) {
-    suspend operator fun invoke(email : String) : BaseResponse<Nothing> {
+    suspend operator fun invoke(email : String, type : AuthCodeCaseType = AuthCodeCaseType.REGISTER) : BaseResponse<Nothing> {
         val emailWithoutSpace = email.removeWhiteSpace()
         if (!isEmailFormat(emailWithoutSpace)) {
             val errorCode = LoginErrorCodes.INVALID_EMAIL_FORMAT
             return BaseResponse.Failure(errorCode = errorCode, errorMessage = errorCodeMapper.mapCodeToString(errorCode))
         }
 
-        val response = repository.issueAuthCode(emailWithoutSpace)
+        val response = repository.issueAuthCode(emailWithoutSpace, type)
         return response.mapErrorCodeToMessageIfFailure(errorCodeMapper::mapCodeToString)
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/reissue_password/ResetPasswordViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/reissue_password/ResetPasswordViewModel.kt
@@ -7,6 +7,7 @@ import com.strayalphaca.presentation.R
 import com.strayalphaca.presentation.models.SignupData
 import com.strayalphaca.presentation.models.Timer
 import com.strayalphaca.presentation.utils.toTimerFormat
+import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseCheckAuthCode
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseIssueAuthCode
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseResetPassword
@@ -68,7 +69,7 @@ class ResetPasswordViewModel @Inject constructor(
     fun tryReIssueAuthCode() {
         viewModelScope.launch {
             _viewState.value = ResetPasswordViewState.ReIssuingAuthCode
-            val response = useCaseIssueAuthCode(email.value)
+            val response = useCaseIssueAuthCode(email = email.value, type = AuthCodeCaseType.RESET_PASSWORD)
 
             // 인증번호 재발급 성공시 타이머 초기화
             if (response is BaseResponse.EmptySuccess) {
@@ -85,7 +86,7 @@ class ResetPasswordViewModel @Inject constructor(
     fun tryCheckAndIssueAuthCode() {
         viewModelScope.launch {
             _viewState.value = ResetPasswordViewState.IssuingAuthCode
-            val response = useCaseIssueAuthCode(email.value)
+            val response = useCaseIssueAuthCode(email = email.value, type = AuthCodeCaseType.RESET_PASSWORD)
 
             // 인증번호 발급 성공시 타이머 실행
             if (response is BaseResponse.EmptySuccess) {
@@ -102,7 +103,7 @@ class ResetPasswordViewModel @Inject constructor(
     fun tryCheckAuthCode() {
         viewModelScope.launch {
             _viewState.value = ResetPasswordViewState.CheckingAuthCode
-            val authCodeCheckResponse = useCaseCheckAuthCode(email.value, authCode.value)
+            val authCodeCheckResponse = useCaseCheckAuthCode(email = email.value, authCode = authCode.value, type = AuthCodeCaseType.RESET_PASSWORD)
 
             if (authCodeCheckResponse is BaseResponse.Failure) {
                 _showToastEvent.emit(authCodeCheckResponse.errorMessage)


### PR DESCRIPTION
- 비밀번호 api 연결
- 인증코드 발급이 회원가입과 비밀번호 재발송의 2가지 경우로 분리되어 사용되므로, 해당 내용을 반영하여 기존 인증코드 발송 api 및 인증코드 확인 api 변경