### PR TITLE
refactor EventFlow

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailViewModel.kt
@@ -7,6 +7,8 @@ import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseDeleteDiary
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryDetail
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.screens.diary.model.MusicPlayer
 import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseHandleCachedCalendarDiary
 import com.strayalphaca.travel_diary.map.usecase.UseCaseRefreshCachedMap
@@ -40,8 +42,8 @@ class DiaryDetailViewModel @Inject constructor(
 
     private val id = savedStateHandle.getStateFlow("diary_id", "")
 
-    private val _goBackNavigationEvent = MutableSharedFlow<Boolean>()
-    val goBackNavigationEvent = _goBackNavigationEvent.asSharedFlow()
+    private val _goBackNavigationEvent = MutableEventFlow<Boolean>()
+    val goBackNavigationEvent = _goBackNavigationEvent.asEventFlow()
 
     fun tryRefresh() {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalpaca.travel_diary.core.domain.model.DiaryDate
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.screens.diary.model.CurrentShowSelectView
 import com.strayalphaca.presentation.screens.diary.model.MediaFileInDiary
 import com.strayalphaca.presentation.screens.diary.model.MusicPlayer
@@ -57,8 +59,8 @@ class DiaryWriteViewModel @Inject constructor(
     private val _writingContent = MutableStateFlow("")
     val writingContent = _writingContent.asStateFlow()
 
-    private val _goBackNavigationEvent = MutableSharedFlow<Boolean>()
-    val goBackNavigationEvent = _goBackNavigationEvent.asSharedFlow()
+    private val _goBackNavigationEvent = MutableEventFlow<Boolean>()
+    val goBackNavigationEvent = _goBackNavigationEvent.asEventFlow()
 
     private val _musicProgress = MutableStateFlow(0f)
     val musicProgress = _musicProgress.asStateFlow()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/home/calendar/CalendarViewModel.kt
@@ -8,6 +8,8 @@ import com.strayalphaca.travel_diary.domain.calendar.usecase.UseCaseGetCalendarD
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.presentation.models.deeplink_handler.DeepLinkEvent
 import com.strayalphaca.presentation.models.deeplink_handler.NotificationDeepLinkHandler
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.utils.collectLatestInScope
 import com.strayalphaca.travel_diary.domain.calendar.utils.fillEmptyCellToCalendarData
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -28,11 +30,11 @@ class CalendarViewModel @Inject constructor(
         .runningFold(CalendarScreenState(), ::reduce)
         .stateIn(viewModelScope, SharingStarted.Eagerly, CalendarScreenState())
 
-    private val _goDiaryWriteNavigationEvent = MutableSharedFlow<Boolean>()
-    val goDiaryWriteNavigationEvent = _goDiaryWriteNavigationEvent.asSharedFlow()
+    private val _goDiaryWriteNavigationEvent = MutableEventFlow<Boolean>()
+    val goDiaryWriteNavigationEvent = _goDiaryWriteNavigationEvent.asEventFlow()
 
-    private val _toastMessage = MutableSharedFlow<String>()
-    val toastMessage = _toastMessage.asSharedFlow()
+    private val _toastMessage = MutableEventFlow<String>()
+    val toastMessage = _toastMessage.asEventFlow()
 
     init {
         tryGetDiaryData(

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/lock/LockViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/lock/LockViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalpaca.travel_diary.domain.lock.use_case.UseCaseCheckPassword
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.screens.lock.model.LockScreenEvent
 import com.strayalphaca.presentation.screens.lock.model.LockScreenSideEffect
 import com.strayalphaca.presentation.screens.lock.model.LockScreenState
@@ -23,8 +25,8 @@ class LockViewModel @Inject constructor(
         .runningFold(LockScreenState(), ::reduce)
         .stateIn(viewModelScope, SharingStarted.Eagerly, LockScreenState())
 
-    private val _sideEffect = MutableSharedFlow<LockScreenSideEffect>()
-    val sideEffect = _sideEffect.asSharedFlow()
+    private val _sideEffect = MutableEventFlow<LockScreenSideEffect>()
+    val sideEffect = _sideEffect.asEventFlow()
 
     fun inputPassword(inputPassword : String) {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/login/LoginViewModel.kt
@@ -3,13 +3,13 @@ package com.strayalphaca.presentation.screens.login_home.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseSaveToken
 import com.strayalphaca.travel_diary.domain.login.model.Tokens
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseLogin
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,8 +31,8 @@ class LoginViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow("")
     val errorMessage = _errorMessage.asStateFlow()
 
-    private val _loginSuccess = MutableSharedFlow<Boolean>()
-    val loginSuccess = _loginSuccess.asSharedFlow()
+    private val _loginSuccess = MutableEventFlow<Boolean>()
+    val loginSuccess = _loginSuccess.asEventFlow()
 
     fun inputEmail(email : String) {
         _email.value = email

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/reissue_password/ResetPasswordViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/reissue_password/ResetPasswordViewModel.kt
@@ -6,15 +6,15 @@ import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.presentation.R
 import com.strayalphaca.presentation.models.SignupData
 import com.strayalphaca.presentation.models.Timer
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.utils.toTimerFormat
 import com.strayalphaca.travel_diary.domain.login.model.AuthCodeCaseType
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseCheckAuthCode
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseIssueAuthCode
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseResetPassword
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -37,8 +37,8 @@ class ResetPasswordViewModel @Inject constructor(
     private val _showResetPasswordSuccessDialog = MutableStateFlow(false)
     val showResetPasswordSuccessDialog = _showResetPasswordSuccessDialog.asStateFlow()
 
-    private val _showToastEvent = MutableSharedFlow<String>()
-    val showToastEvent = _showToastEvent.asSharedFlow()
+    private val _showToastEvent = MutableEventFlow<String>()
+    val showToastEvent = _showToastEvent.asEventFlow()
 
     private val _timerValue = MutableStateFlow("")
     val timerValue = _timerValue.asStateFlow()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/signup_password/SignupPasswordViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/signup_password/SignupPasswordViewModel.kt
@@ -7,10 +7,10 @@ import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.presentation.components.atom.base_button.BaseButtonState
 import com.strayalphaca.presentation.components.block.EditTextState
 import com.strayalphaca.presentation.models.SignupData
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,8 +28,8 @@ class SignupPasswordViewModel @Inject constructor(
     private val _errorMessage = MutableStateFlow("")
     val errorMessage = _errorMessage.asStateFlow()
 
-    private val _signUpSuccessEvent = MutableSharedFlow<Boolean>()
-    val signupSuccessEvent = _signUpSuccessEvent.asSharedFlow()
+    private val _signUpSuccessEvent = MutableEventFlow<Boolean>()
+    val signupSuccessEvent = _signUpSuccessEvent.asEventFlow()
 
     fun inputPassword(password : String) {
         _password.value = password

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/singup_email/SignupEmailViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/login_home/singup_email/SignupEmailViewModel.kt
@@ -8,11 +8,11 @@ import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.presentation.R
 import com.strayalphaca.presentation.models.SignupData
 import com.strayalphaca.presentation.models.Timer
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.utils.toTimerFormat
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -31,11 +31,11 @@ class SignupEmailViewModel @Inject constructor(
     private val _authCode = MutableStateFlow("")
     val authCode = _authCode.asStateFlow()
 
-    private val _moveToPasswordEvent = MutableSharedFlow<Boolean>()
-    val moveToPasswordEvent = _moveToPasswordEvent.asSharedFlow()
+    private val _moveToPasswordEvent = MutableEventFlow<Boolean>()
+    val moveToPasswordEvent = _moveToPasswordEvent.asEventFlow()
 
-    private val _showToastEvent = MutableSharedFlow<String>()
-    val showToastEvent = _showToastEvent.asSharedFlow()
+    private val _showToastEvent = MutableEventFlow<String>()
+    val showToastEvent = _showToastEvent.asEventFlow()
 
     private val _timerValue = MutableStateFlow("")
     val timerValue = _timerValue.asStateFlow()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/change_password/ChangePasswordViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/change_password/ChangePasswordViewModel.kt
@@ -3,14 +3,14 @@ package com.strayalphaca.presentation.screens.settings.change_password
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseChangePassword
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.runningFold
@@ -28,8 +28,8 @@ class ChangePasswordViewModel @Inject constructor(
     private val _newPassword = MutableStateFlow("")
     val newPassword = _newPassword.asStateFlow()
 
-    private val _changePasswordSuccess = MutableSharedFlow<Boolean>()
-    val changePasswordSuccess = _changePasswordSuccess.asSharedFlow()
+    private val _changePasswordSuccess = MutableEventFlow<Boolean>()
+    val changePasswordSuccess = _changePasswordSuccess.asEventFlow()
 
     private val events = Channel<ChangePasswordScreenEvent>()
     val state: StateFlow<ChangePasswordScreenState> = events.receiveAsFlow()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/home/SettingsHomeViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/home/SettingsHomeViewModel.kt
@@ -3,14 +3,14 @@ package com.strayalphaca.presentation.screens.settings.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalphaca.presentation.alarm.TrailyAlarmManager
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.travel_diary.domain.alarm.model.AlarmInfo
 import com.strayalphaca.travel_diary.domain.alarm.usecase.UseCaseSetAlarmInfo
 import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseClearToken
 import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseGetAccessToken
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -28,8 +28,8 @@ class SettingsHomeViewModel @Inject constructor(
     private val _logoutCheckDialogVisible = MutableStateFlow(false)
     val logoutCheckDialogVisible = _logoutCheckDialogVisible.asStateFlow()
 
-    private val _navigateToIntroEvent = MutableSharedFlow<Boolean>()
-    val navigateToIntroEvent = _navigateToIntroEvent.asSharedFlow()
+    private val _navigateToIntroEvent = MutableEventFlow<Boolean>()
+    val navigateToIntroEvent = _navigateToIntroEvent.asEventFlow()
 
     fun showLogoutCheckDialog() {
         _logoutCheckDialogVisible.value = true

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/withdrawal/WithdrawalViewModel.kt
@@ -4,12 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalphaca.travel_diary.domain.login.use_case.UseCaseWithdrawal
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.travel_diary.diary.use_case.UseCaseGetDiaryCount
 import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseClearToken
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -29,11 +29,11 @@ class WithdrawalViewModel @Inject constructor(
     private val _deleteLoading = MutableStateFlow(false)
     val deleteLoading = _deleteLoading.asStateFlow()
 
-    private val _toastMessage = MutableSharedFlow<String>()
-    val toastMessage = _toastMessage.asSharedFlow()
+    private val _toastMessage = MutableEventFlow<String>()
+    val toastMessage = _toastMessage.asEventFlow()
 
-    private val _withdrawalSuccess = MutableSharedFlow<Boolean>()
-    val withdrawalSuccess = _withdrawalSuccess.asSharedFlow()
+    private val _withdrawalSuccess = MutableEventFlow<Boolean>()
+    val withdrawalSuccess = _withdrawalSuccess.asEventFlow()
 
     private val _showCheckDialog = MutableStateFlow(false)
     val showCheckDialog = _showCheckDialog.asStateFlow()

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/start/StartViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/start/StartViewModel.kt
@@ -2,11 +2,11 @@ package com.strayalphaca.presentation.screens.start
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.travel_diary.domain.auth.usecase.UseCaseGetAccessToken
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -15,8 +15,8 @@ class StartViewModel @Inject constructor(
     private val useCaseGetAccessToken: UseCaseGetAccessToken
 ) : ViewModel() {
 
-    private val _navigationEvent = MutableSharedFlow<StartScreenNavDestination>()
-    val navigationEvent = _navigationEvent.asSharedFlow()
+    private val _navigationEvent = MutableEventFlow<StartScreenNavDestination>()
+    val navigationEvent = _navigationEvent.asEventFlow()
 
     init {
         checkHasAccessToken()


### PR DESCRIPTION
화면이동, 토스트 메세지와 같은 단발성 이벤트에 대한 ViewModel내 관찰 가능한 변수 타입을 SharedFlow에서 EventFlow로 변경
- MutableSharedFlow -> MutableEventFlow
- SharedFlow -> EventFlow

단, 단발성이 아닌 여러 collector에서 수집될 수 있는 data레이어의 SharedFlow는 그대로 유지