### PR TITLE
[fix] release 버젼 빌드시 난독화 제외 대상 지 및 release시 난독화 사용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,15 @@ android {
     namespace 'com.strayalphaca.travel_diary'
     compileSdk 33
 
+    signingConfigs {
+        release {
+            keyAlias properties["key_alias"]
+            keyPassword properties["key_password"]
+            storeFile file(properties["store_file"])
+            storePassword properties["store_password"]
+        }
+    }
+
     defaultConfig {
         applicationId "com.strayalphaca.travel_diary"
         minSdk 24
@@ -29,7 +38,8 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
+            signingConfig signingConfigs.release
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,10 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+-keep class com.strayalphaca.travel_diary.map.model.* {*;}
+-keep class com.strayalphaca.travel_diary.data.login.model.* {*;}
+-keep class com.strayalphaca.travel_diary.data.calendar.models.* {*;}
+-keep class com.strayalphaca.travel_diary.data.diary.model.* {*;}
+-keep class com.strayalphaca.travel_diary.data.file.model.* {*;}
+-keep class com.strayalphaca.travel_diary.data.map.model.* {*;}
+-keep class com.strayalphaca.travel_diary.core.data.model.* {*;}


### PR DESCRIPTION
- android studio에서 앱 run시 사용할 keystore에 대한 정보는 local.properties에 작성되어 있습니다.
- retrofit에서 requestBody, responseBody로 사용되는 데이터 클래스들을 난독화 대상에서 제외합니다.
- City, Province sealed class에서 reflection을 사용한 sealedSubclasses 메서드를 호출하기에, 이와 관련된 Map 도메인 관련 model들을 난독화 대상에서 제외합니다.