### PR TITLE
Fix network

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/NetworkModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/NetworkModule.kt
@@ -76,6 +76,22 @@ object NetworkModule {
             .build()
     }
 
+    @NoHeaderClient
+    @Singleton
+    @Provides
+    fun provideNoHeaderRetrofit(): Retrofit {
+        val client = OkHttpClient.Builder()
+            .connectTimeout(connect_timeout_milli, TimeUnit.MILLISECONDS)
+            .writeTimeout(write_timeout_milli, TimeUnit.MILLISECONDS)
+            .readTimeout(read_timeout_milli, TimeUnit.MILLISECONDS)
+            .build()
+
+        return Retrofit.Builder()
+            .baseUrl(base_url)
+            .client(client)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
 }
 
 @Qualifier
@@ -85,3 +101,7 @@ annotation class ReissueClient
 @Qualifier
 @Retention(AnnotationRetention.BINARY)
 annotation class BaseClient
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class NoHeaderClient

--- a/app/src/main/java/com/strayalphaca/travel_diary/network/RequestInterceptor.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/network/RequestInterceptor.kt
@@ -22,7 +22,7 @@ class RequestInterceptor @Inject constructor(
             return Response.Builder()
                 .request(request)
                 .protocol(Protocol.HTTP_1_1)
-                .code(407)
+                .code(408)
                 .message("socket timeout error")
                 .body("{${e}}".toResponseBody(null)).build()
         }
@@ -45,6 +45,7 @@ class RequestInterceptor @Inject constructor(
         }
 
         val requestAfterRefreshToken = setRequestHeader(chain)
+        response.close()
         return chain.proceed(requestAfterRefreshToken)
     }
 


### PR DESCRIPTION
RequestInterceptor에서 아래 부분을 수정
- socket timeout 발생시 Response의 응답 코드를 407에서 408로 변경
- chain.proceed 리턴 전 이전 request의 response를 close하는 코드 추가

로그인, 회원가입과 같이 request header에 토큰 정보를 넣을 필요가 없는 api에 사용할 별도의 retrofit 객체 생성 및 주입 코드 작성