### PR TITLE
Fix diary

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
@@ -18,6 +18,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
+import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -29,6 +30,8 @@ abstract class DiaryModule {
 @Module
 @InstallIn(SingletonComponent::class)
 object DiaryProvideModule {
+
+    @Singleton
     @Provides
     fun provideDiaryRepository(
         @BaseClient retrofit : Retrofit,

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -235,6 +235,7 @@ class DiaryWriteViewModel @Inject constructor(
                         medias = mediaFileIdList,
                         voice = voiceFileId,
                         cityId = state.value.cityId,
+                        cityName = state.value.cityName,
                         date = state.value.diaryDate
                     )
                 )


### PR DESCRIPTION
- 일지 수정 화면에서 일지 수정 내역을 수정할 때, 인자 객체에 지역 이름을 누락한 부분 수정
- DiaryRepositry구현체가 singleton으로 주입되지 않아, 일지 삭제/수정 내역이 일지 리스트 화면에 반영되지 않던 문제 수정