### PR TITLE
Fix alarm

### DIFF
--- a/core/presentation/src/main/java/com/strayalphaca/travel_diary/core/presentation/utils/PermissionUtils.kt
+++ b/core/presentation/src/main/java/com/strayalphaca/travel_diary/core/presentation/utils/PermissionUtils.kt
@@ -1,0 +1,40 @@
+package com.strayalphaca.travel_diary.core.presentation.utils
+
+import android.Manifest
+import android.app.AlarmManager
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+
+val EXACT_ALARM_PERMISSION = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+    Manifest.permission.SCHEDULE_EXACT_ALARM
+} else {
+    null
+}
+
+
+fun checkExactAlarmAvailable(context: Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        alarmManager.canScheduleExactAlarms()
+    } else {
+        true
+    }
+}
+
+
+val POST_NOTIFICATIONS_33 =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.POST_NOTIFICATIONS
+    } else {
+        null
+    }
+
+
+fun checkPostNotificationAvailable(context: Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+    } else {
+        true
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmScreen.kt
@@ -88,7 +88,7 @@ fun PushAlarmScreen(
                 !it.shouldShowRequestPermissionRationale(Manifest.permission.POST_NOTIFICATIONS)
             } ?: true,
             onDismissRequest = viewModel::dismissPermissionRequestDialog,
-            goToSettingClick = { context.findActivity()?.openAppSettings() }
+            goToSettingClick = { context.findActivity()?.openAppSettings(requestPermissionSettingAction ?: Settings.ACTION_APPLICATION_DETAILS_SETTINGS) }
         )
     }
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmScreen.kt
@@ -3,6 +3,7 @@ package com.strayalphaca.presentation.screens.settings.push_alarm
 import android.Manifest
 import android.app.TimePickerDialog
 import android.os.Build
+import android.provider.Settings
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -30,6 +31,9 @@ import com.strayalphaca.presentation.ui.theme.Gray4
 import com.strayalphaca.presentation.utils.findActivity
 import com.strayalphaca.presentation.utils.minuteIn24HourToHour12
 import com.strayalphaca.presentation.utils.openAppSettings
+import com.strayalphaca.travel_diary.core.presentation.utils.EXACT_ALARM_PERMISSION
+import com.strayalphaca.travel_diary.core.presentation.utils.POST_NOTIFICATIONS_33
+import com.strayalphaca.travel_diary.core.presentation.utils.checkExactAlarmAvailable
 
 @Composable
 fun PushAlarmScreen(
@@ -40,7 +44,7 @@ fun PushAlarmScreen(
     val usePushAlarm by viewModel.usePushAlarm.collectAsState()
     val pushAlarmMinute by viewModel.pushAlarmMinute.collectAsState()
     val targetUrl by viewModel.clickTarget.collectAsState()
-    val isShowPermissionRequestDialog by viewModel.isShowPermissionRequestDialog.collectAsState()
+    val requestPermissionSettingAction by viewModel.requestPermissionSettingAction.collectAsState()
 
     val timePickerDialog = TimePickerDialog(
         context,
@@ -52,19 +56,31 @@ fun PushAlarmScreen(
         false
     )
 
-    val launcher =
+    val exactNotificationPermissionsLauncher =
         rememberLauncherForActivityResult(
-            ActivityResultContracts.RequestPermission(),
-            onResult = { isGranted ->
-                if (isGranted) {
-                    viewModel.setUsePushAlarm(true)
-                } else {
-                    viewModel.showPermissionRequestDialog()
-                }
+            contract = ActivityResultContracts.RequestMultiplePermissions(),
+            onResult = { permissionGrantMap ->
+                permissionGrantMap.values
+                    .all { it }
+                    .let { allGranted ->
+                        when {
+                            !allGranted -> {
+                                viewModel.showPermissionRequestDialog(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                            }
+                            checkExactAlarmAvailable(context) -> {
+                                viewModel.setUsePushAlarm(true)
+                            }
+                            else -> {
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                    viewModel.showPermissionRequestDialog(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                                }
+                            }
+                        }
+                    }
             }
         )
 
-    if (isShowPermissionRequestDialog && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+    if (requestPermissionSettingAction != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
         PermissionRequestDialog(
             title = stringResource(id = R.string.deny_permission),
             message = stringResource(id = R.string.permission_description_post_notification),
@@ -86,10 +102,14 @@ fun PushAlarmScreen(
             checked = usePushAlarm,
             onCheckedChange = { useAlarm ->
                 if (useAlarm) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU)
-                        launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
-                    else
-                        viewModel.setUsePushAlarm(true)
+                    listOfNotNull(EXACT_ALARM_PERMISSION, POST_NOTIFICATIONS_33).let { permissionList ->
+                        if (permissionList.isEmpty()) {
+                            viewModel.setUsePushAlarm(true)
+                            return@let
+                        }
+
+                        exactNotificationPermissionsLauncher.launch(permissionList.toTypedArray())
+                    }
                 } else {
                     viewModel.setUsePushAlarm(false)
                 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/push_alarm/PushAlarmViewModel.kt
@@ -33,8 +33,8 @@ class PushAlarmViewModel @Inject constructor(
     private val _clickTarget = MutableStateFlow(Route.pushAlarmTargetList.last())
     val clickTarget: StateFlow<Route?> = _clickTarget.asStateFlow()
 
-    private val _isShowPermissionRequestDialog = MutableStateFlow(false)
-    val isShowPermissionRequestDialog = _isShowPermissionRequestDialog.asStateFlow()
+    private val _requestPermissionSettingAction = MutableStateFlow<String?>(null)
+    val requestPermissionSettingAction  =_requestPermissionSettingAction.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -93,11 +93,11 @@ class PushAlarmViewModel @Inject constructor(
         }
     }
 
-    fun showPermissionRequestDialog() {
-        _isShowPermissionRequestDialog.value = true
+    fun showPermissionRequestDialog(action : String) {
+        _requestPermissionSettingAction.value = action
     }
 
     fun dismissPermissionRequestDialog() {
-        _isShowPermissionRequestDialog.value = false
+        _requestPermissionSettingAction.value = null
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/utils/ContextUtils.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/utils/ContextUtils.kt
@@ -30,9 +30,9 @@ internal fun Context.findActivity() : Activity? {
 }
 
 
-fun Activity.openAppSettings() {
+fun Activity.openAppSettings(action : String = Settings.ACTION_APPLICATION_DETAILS_SETTINGS) {
     Intent(
-        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+        action,
         Uri.fromParts("package", packageName, null)
     ).also (::startActivity)
 }


### PR DESCRIPTION
https://developer.android.com/about/versions/14/changes/schedule-exact-alarms#migration
정확한 알림 사용여부가 기본적으로 거부됨에 따라, 알림 설정 화면에서 알림 사용시 정확한 알림 사용 권한도 같이 요청 및 검사하도록 수정