### PR TITLE
Fix diary

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/DiaryModule.kt
@@ -18,7 +18,6 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
-import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -31,7 +30,6 @@ abstract class DiaryModule {
 @InstallIn(SingletonComponent::class)
 object DiaryProvideModule {
 
-    @Singleton
     @Provides
     fun provideDiaryRepository(
         @BaseClient retrofit : Retrofit,

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/demo_data_source/DemoDataSourceImpl.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/demo_data_source/DemoDataSourceImpl.kt
@@ -7,7 +7,9 @@ import com.strayalphaca.travel_diary.core.data.model.DiaryItemDto
 import com.strayalphaca.travel_diary.core.data.model.ImageDto
 import com.strayalphaca.travel_diary.core.data.model.MediaFileInfoDto
 import java.util.Calendar
+import javax.inject.Singleton
 
+@Singleton
 class DemoDataSourceImpl : DemoDataSource {
     override fun getDiaryDetail(id: String): DiaryDto {
         return dataList.find { it.id == id } ?: throw IllegalStateException("Cannot found diary, id : $id")

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -108,7 +108,7 @@ class DiaryWriteViewModel @Inject constructor(
 
     fun inputContent(content : String) {
         viewModelScope.launch {
-            _writingContent.value = content
+            _writingContent.update { content }
         }
     }
 
@@ -185,7 +185,7 @@ class DiaryWriteViewModel @Inject constructor(
         musicPlayerJob = viewModelScope.launch {
             while (true) {
                 if (state.value.musicPlaying) {
-                    _musicProgress.value = musicPlayer.getProgress()
+                    _musicProgress.update { musicPlayer.getProgress() }
                 }
                 delay(250L)
             }
@@ -195,7 +195,7 @@ class DiaryWriteViewModel @Inject constructor(
     fun dragMusicProgressByUser(progress : Float) {
         pauseMusic()
         musicPlayer.setPosition(progress)
-        _musicProgress.value = progress
+        _musicProgress.update { progress }
     }
 
     fun uploadDiary() {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.rememberScrollState
@@ -38,7 +40,9 @@ import com.strayalphaca.presentation.ui.theme.Gray2
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -143,6 +147,8 @@ fun DiaryWriteScreen(
 ) {
     val scrollState = rememberScrollState()
     val lifecycleOwner = LocalLifecycleOwner.current
+    val interactionSource = remember { MutableInteractionSource() }
+    val focusManager = LocalFocusManager.current
 
     val photoPickerLauncher = if (3 - state.imageFiles.size > 1) {
         rememberLauncherForActivityResult(
@@ -197,7 +203,16 @@ fun DiaryWriteScreen(
     }
 
     Surface {
-        Column(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null
+                ) {
+                    focusManager.clearFocus()
+                }
+        ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,


### PR DESCRIPTION
- 로그아웃 이후 비회원으로 둘러보기 기능 중 일지 조회시 비정상적인 토큰 인증 문제가 발생한 문제 수정
  - 의존성 주입시 DiaryRepository를 제공하는 Provider함수를 Singleton으로 선언한 것 때문에 발생한 문제이며, 해당 Provider에서 Singleton 어노테이션을 제거한 후, 싱글톤으로 유지되어야 하는 DemoDataSource 클래스에 Singleton 어노테이션 추가
- 일지 작성 중 BasicTextField의 외부를 클릭하면 TextField의 focus를 제거하도록 수정
- 일지 작성 viewModel에서 stateFlow의 갱신 방법은 .value를 사용하던 방법에서 .update로 변경하여 값을 변경할 때 원시성을 보장하도록 수정