### PR TITLE
[hot fix] Room 사용시 일지 제거 후 앱 강제종료 현상 수정

### DIFF
--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
@@ -26,9 +26,9 @@ class MapLocalDataSource @Inject constructor(
     }
 
     override suspend fun getDiaryListInProvince(provinceId: Int): BaseResponse<List<LocationDiary>> {
-        val recordItemList = recordDao.getRecordInMapProvince(provinceId).groupBy { it.cityGroupId }.values.first()
+        val recordItemList = recordDao.getRecordInMapProvince(provinceId).groupBy { it.cityGroupId }.values.firstOrNull()
 
-        val response = recordItemList.map { recordItem ->
+        val response = recordItemList?.map { recordItem ->
             LocationDiary(
                 thumbnailUri = recordItem.imageUri,
                 location = Location(
@@ -39,7 +39,7 @@ class MapLocalDataSource @Inject constructor(
                 ),
                 id = recordItem.id.toString()
             )
-        }
+        } ?: emptyList()
         return BaseResponse.Success(data = response)
     }
 }


### PR DESCRIPTION
Room 사용중 지도 화면 -> 일지 목록 -> 일지 상세에서 일지 삭제시, 해당 일지가 지역의 마지막 일지인 경우 앱이 강제종료되는 현상 수정