### PR TITLE
[fix] 회원탈퇴 다이얼로그에서 탈퇴 확인 버튼의 텍스트를 "결정" 에서 "확인" 으로 변경

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CheckByInputTextDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/CheckByInputTextDialog.kt
@@ -87,7 +87,7 @@ fun CheckByInputTextDialog(
                     },
                     enabled = (content == targetText)
                 ) {
-                    Text(text = stringResource(id = R.string.confirm), color = MaterialTheme.colors.onSurface)
+                    Text(text = stringResource(id = R.string.check), color = MaterialTheme.colors.onSurface)
                 }
             }
         }


### PR DESCRIPTION
- 회원탈퇴/데이터 초기화 다이얼로그의 메세지에서 "회원탈퇴를 원하시면, 회원탈퇴를 입력한 후 '확인' 버튼을 눌러주세요" 라고 표시되어 있었지만, 버튼 텍스트는 '결정'으로 되어 있어 이를 '확인'으로 수정