### PR TITLE
Fix ui

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/components/atom/diary_default_image/DiaryDefaultImage.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/atom/diary_default_image/DiaryDefaultImage.kt
@@ -1,0 +1,23 @@
+package com.strayalphaca.presentation.components.atom.diary_default_image
+
+import androidx.compose.foundation.Image
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import com.strayalphaca.presentation.R
+
+@Composable
+fun DiaryDefaultImage(
+    modifier : Modifier = Modifier
+) {
+    Image(
+        modifier = modifier,
+        painter = painterResource(id = R.drawable.ic_logo),
+        contentDescription = "default_image",
+        contentScale = ContentScale.Fit,
+        colorFilter = ColorFilter.tint(Color.Black)
+    )
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/CalendarItemView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/CalendarItemView.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.strayalphaca.presentation.components.atom.diary_default_image.DiaryDefaultImage
 import com.strayalphaca.travel_diary.domain.calendar.model.DiaryInCalendar
 import com.strayalphaca.presentation.ui.theme.Gray4
 import com.strayalphaca.presentation.ui.theme.Tape
@@ -35,14 +36,25 @@ fun CalendarItemView(modifier: Modifier = Modifier, item: DiaryInCalendar, isTod
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(0.8f)
                     .background(Tape)
             ) {
-                AsyncImage(
-                    model = item.thumbnailUrl,
-                    contentDescription = "thumbnail_image",
-                    contentScale = ContentScale.Crop
-                )
+                if (item.thumbnailUrl != null) {
+                    AsyncImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f),
+                        model = item.thumbnailUrl,
+                        contentDescription = "thumbnail_image",
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    DiaryDefaultImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f)
+                    )
+                }
+
             }
 
             Spacer(modifier = Modifier.height(10.dp))

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryInMap.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.strayalphaca.presentation.components.atom.diary_default_image.DiaryDefaultImage
 import com.strayalphaca.presentation.ui.theme.Tape
 import com.strayalphaca.presentation.utils.pxToDp
 
@@ -31,21 +32,18 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding((widthPx * 0.05f).toInt().pxToDp())
-        ) {
-            if (thumbnailUrl == null) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(0.8f)
-                        .background(Tape)
+                .padding(
+                    (widthPx * 0.05f)
+                        .toInt()
+                        .pxToDp()
                 )
-            } else {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .background(Tape)
-                ) {
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Tape)
+            ) {
+                if (thumbnailUrl != null) {
                     AsyncImage(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -54,8 +52,13 @@ fun DiaryInMap(modifier: Modifier, onClick : (Int) -> Unit, thumbnailUrl : Strin
                         contentDescription = "thumbnail_image",
                         contentScale = ContentScale.Crop
                     )
+                } else {
+                    DiaryDefaultImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f)
+                    )
                 }
-
             }
 
             Spacer(modifier = Modifier

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryItemView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/DiaryItemView.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -21,6 +20,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import com.strayalphaca.presentation.components.atom.diary_default_image.DiaryDefaultImage
 import com.strayalphaca.presentation.ui.theme.Tape
 
 @Composable
@@ -47,15 +47,22 @@ fun DiaryItemView(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .aspectRatio(0.8f)
                     .background(Tape)
             ) {
-                imageUrl?.let{ imageUrl ->
+                if (imageUrl != null) {
                     AsyncImage(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f),
                         model = imageUrl,
                         contentDescription = "image",
                         contentScale = ContentScale.Crop
+                    )
+                } else {
+                    DiaryDefaultImage(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(0.8f)
                     )
                 }
             }


### PR DESCRIPTION
- 달력/지도/일지 목록 화면에서 이미지가 없는 일지 아이템의 경우, 이전에는 단일 색상만을 이미지 영역에서 보여주었으나, 해당 부분을 앱 로고 이미지로 보여지도록 수정

<p align="center">
  <img src="https://github.com/l5x5l/travel_diary/assets/39579912/1e5e9ac8-b4c9-46cc-9eb8-4baa51a76a0e" align="center" width="40%">
  <img src="https://github.com/l5x5l/travel_diary/assets/39579912/a65aa71d-21e8-4e97-ba84-3ef2233a1419" align="center" width="40%">
</p>
