### PR TITLE
[fix] Room 일지 목록 조회시 동일한 id를 가진 일지가 중복되서 리턴되는 현상 수정

### DIFF
--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
@@ -8,6 +8,8 @@ import com.strayalphaca.travel_diary.core.data.room.entity.FileEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.LocationEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordFileEntity
+import com.strayalphaca.travel_diary.core.data.room.model.FileItem
+import com.strayalphaca.travel_diary.core.data.room.model.RecordItem
 
 @Dao
 interface RecordDao {
@@ -33,7 +35,7 @@ interface RecordDao {
     // 달력 일지 조회
     // 이게 문제다, join을 해서, 동일한 id를 가진 일지가 여러개 생긴 거다.
     @Query(
-        "SELECT r.id, r.createdAt as date, f.filePath as imageUri, r.locationId as locationId FROM RecordEntity r " +
+        "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "WHERE r.createdAt LIKE :dateQuery || '%' AND ( rf.positionInRecord = 0 OR rf.positionInRecord is null ) "
@@ -42,7 +44,7 @@ interface RecordDao {
 
     // 지도 일지 조회 - 전국 지도
     @Query(
-        "SELECT r.id, r.createdAt as date, f.filePath as imageUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId FROM RecordEntity r " +
+        "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
@@ -52,7 +54,7 @@ interface RecordDao {
 
     // 지도 일지 조회 - 광역시/도 기준
     @Query(
-        "SELECT r.id, r.createdAt as date, f.filePath as imageUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId FROM RecordEntity r " +
+        "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
@@ -62,7 +64,7 @@ interface RecordDao {
 
     // 일지 리스트 조회 - 단일 도시 기준
     @Query(
-        "SELECT r.id, r.createdAt as date, f.filePath as imageUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId FROM RecordEntity r " +
+        "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
@@ -73,7 +75,7 @@ interface RecordDao {
 
     // 일지 리스트 조회 - 도시 그룹 기준
     @Query(
-        "SELECT r.id, r.createdAt as date, f.filePath as imageUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId FROM RecordEntity r " +
+        "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, l.provinceId as provinceId, l.cityGroupId as cityGroupId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
@@ -112,20 +114,4 @@ interface RecordDao {
 
     @Query("SELECT * FROM LocationEntity")
     suspend fun getLocations() : List<LocationEntity>
-
-    data class RecordItem(
-        val id : Int,
-        val date : String,
-        val imageUri : String?,
-        val locationId : Int?,
-        val provinceId : Int?,
-        val cityGroupId : Int?
-    )
-
-    data class FileItem(
-        val id : Int,
-        val filePath : String,
-        val type : String,
-        val positionInRecord : Int
-    )
 }

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/FileItem.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/FileItem.kt
@@ -1,0 +1,8 @@
+package com.strayalphaca.travel_diary.core.data.room.model
+
+data class FileItem(
+    val id : Int,
+    val filePath : String,
+    val type : String,
+    val positionInRecord : Int
+)

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
@@ -1,0 +1,30 @@
+package com.strayalphaca.travel_diary.core.data.room.model
+
+data class RecordItem(
+    val id : Int,
+    val date : String,
+    val fileUri : String?,
+    val locationId : Int?,
+    val provinceId : Int?,
+    val cityGroupId : Int?,
+    val fileType : String?
+) {
+    companion object {
+        val recordItemComparatorOnSameId =
+            Comparator<RecordItem> { a, b ->
+                when {
+                    a.fileType == "Image" || a.fileType == "Video" -> return@Comparator -1
+                    b.fileType == "Image" || b.fileType == "Video" -> return@Comparator 1
+                    a.fileUri != null -> return@Comparator -1
+                    b.fileUri != null -> return@Comparator 1
+                    else -> return@Comparator 0
+                }
+            }
+    }
+}
+
+fun List<RecordItem>.getSingleItemPerId() : List<RecordItem> {
+    return this.groupBy { it.id }
+        .map { it.value.sortedWith(RecordItem.recordItemComparatorOnSameId).first() }
+        .sortedBy { it.date }
+}

--- a/core/data/src/test/java/com/strayalphaca/travel_diary/core/data/RecordItemSortTest.kt
+++ b/core/data/src/test/java/com/strayalphaca/travel_diary/core/data/RecordItemSortTest.kt
@@ -1,0 +1,36 @@
+package com.strayalphaca.travel_diary.core.data
+
+import com.strayalphaca.travel_diary.core.data.room.model.RecordItem
+import com.strayalphaca.travel_diary.core.data.room.model.getSingleItemPerId
+import org.junit.Before
+import org.junit.Test
+
+class RecordItemSortTest {
+    private var recordItemList : List<RecordItem> = listOf()
+
+    private fun getInitData() : List<RecordItem> {
+        return listOf(
+            RecordItem(id=37, date="2024-02-01", fileUri="/sdcard/.transforms/synthetic/picker/0/com.android.providers.media.photopicker/media/1000000021.jpg", locationId=null, provinceId=null, cityGroupId=null, fileType = "Image"),
+            RecordItem(id=38, date="2024-02-02", fileUri=null, locationId=null, provinceId=null, cityGroupId=null, fileType = null),
+            RecordItem(id=39, date="2024-02-03", fileUri="/sdcard/.transforms/synthetic/picker/0/com.android.providers.media.photopicker/media/1000000021.jpg", locationId=129, provinceId=null, cityGroupId=null, fileType = "Image"),
+            RecordItem(id=40, date="2024-02-04", fileUri="/sdcard/.transforms/synthetic/picker/0/com.android.providers.media.photopicker/media/1000000021.jpg", locationId=69, provinceId=null, cityGroupId=null, fileType = "Image"),
+            RecordItem(id=41, date="2024-02-07", fileUri="content:/com.android.providers.downloads.documents/document/msf%3A1000000020", locationId=null, provinceId=null, cityGroupId=null, fileType = "Voice"),
+            RecordItem(id=42, date="2024-02-10", fileUri=null, locationId=null, provinceId=null, cityGroupId=null, fileType = null),
+            RecordItem(id=43, date="2024-02-08", fileUri="content:/com.android.providers.downloads.documents/document/msf%3A1000000019", locationId=null, provinceId=null, cityGroupId=null, fileType = "Voice"),
+            RecordItem(id=43, date="2024-02-08", fileUri="/sdcard/.transforms/synthetic/picker/0/com.android.providers.media.photopicker/media/1000000021.jpg", locationId=null, provinceId=null, cityGroupId=null, fileType = "Image")
+        )
+    }
+
+    @Before
+    fun setUp() {
+        recordItemList = getInitData()
+    }
+
+    @Test
+    fun recordItemList_getOneItemPerId() {
+        val handledRecordItemList = recordItemList.getSingleItemPerId()
+
+        assert(!handledRecordItemList.contains(RecordItem(id=43, date="2024-02-08", fileUri="content:/com.android.providers.downloads.documents/document/msf%3A1000000019", locationId=null, provinceId=null, cityGroupId=null, fileType = "Voice"),))
+        assert(handledRecordItemList.contains(RecordItem(id=43, date="2024-02-08", fileUri="/sdcard/.transforms/synthetic/picker/0/com.android.providers.media.photopicker/media/1000000021.jpg", locationId=null, provinceId=null, cityGroupId=null, fileType = "Image")))
+    }
+}

--- a/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarLocalDataSource.kt
+++ b/data/calendar/src/main/java/com/strayalphaca/travel_diary/data/calendar/data_source/CalendarLocalDataSource.kt
@@ -4,6 +4,7 @@ import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalpaca.travel_diary.core.domain.model.DiaryDate
 import com.strayalphaca.travel_diary.core.data.model.ImageDto
 import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
+import com.strayalphaca.travel_diary.core.data.room.model.getSingleItemPerId
 import com.strayalphaca.travel_diary.data.calendar.models.CalendarDiaryDto
 import java.util.Calendar
 import javax.inject.Inject
@@ -14,13 +15,15 @@ class CalendarLocalDataSource @Inject constructor(
     private val recordDao: RecordDao
 ) : CalendarDataSource {
     override suspend fun getDiaryData(year: Int, month: Int): BaseResponse<List<CalendarDiaryDto>> {
-        val data = recordDao.getRecordInCalendar("%04d-%02d".format(year, month)).map { recordItem ->
-            CalendarDiaryDto(
-                id = recordItem.id.toString(),
-                image = recordItem.imageUri?.let { ImageDto(it, it, it) },
-                recordDate = recordItem.date
-            )
-        }
+        val data = recordDao.getRecordInCalendar("%04d-%02d".format(year, month))
+            .getSingleItemPerId()
+            .map { recordItem ->
+                CalendarDiaryDto(
+                    id = recordItem.id.toString(),
+                    image = recordItem.fileUri?.let { ImageDto(it, it, it) },
+                    recordDate = recordItem.date
+                )
+            }
         return BaseResponse.Success(data = data)
     }
 

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryLocalDataSource.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryLocalDataSource.kt
@@ -10,6 +10,7 @@ import com.strayalphaca.travel_diary.core.data.model.VoiceFileInDiaryDto
 import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordFileEntity
+import com.strayalphaca.travel_diary.core.data.room.model.getSingleItemPerId
 import com.strayalphaca.travel_diary.diary.model.DiaryModifyData
 import com.strayalphaca.travel_diary.diary.model.DiaryWriteData
 import com.strayalphaca.travel_diary.map.model.City
@@ -38,14 +39,16 @@ class DiaryLocalDataSource @Inject constructor(
     }
 
     override suspend fun getDiaryList(cityId: Int, perPage: Int, offset: Int): List<DiaryItemDto> {
-        return recordDao.getRecordListInCity(cityId, perPage = perPage, pageIdx = offset).map { recordItem ->
-            DiaryItemDto(
-                id = recordItem.id.toString(),
-                image = recordItem.imageUri?.let { ImageDto(originalName = it, uploadedLink = it, shortLink = it) },
-                city = City.findCity(recordItem.locationId!!).run { CityDto(id = id, name = name) },
-                provinceId = recordItem.provinceId!!
-            )
-        }
+        return recordDao.getRecordListInCity(cityId, perPage = perPage, pageIdx = offset)
+            .getSingleItemPerId()
+            .map { recordItem ->
+                DiaryItemDto(
+                    id = recordItem.id.toString(),
+                    image = recordItem.fileUri?.let { ImageDto(originalName = it, uploadedLink = it, shortLink = it) },
+                    city = City.findCity(recordItem.locationId!!).run { CityDto(id = id, name = name) },
+                    provinceId = recordItem.provinceId!!
+                )
+            }
     }
 
     override suspend fun getDiaryListByCityGroup(
@@ -53,14 +56,16 @@ class DiaryLocalDataSource @Inject constructor(
         perPage: Int,
         offset: Int
     ): List<DiaryItemDto> {
-        return recordDao.getRecordListInCityGroup(cityGroupId, perPage = perPage, pageIdx = offset).map { recordItem ->
-            DiaryItemDto(
-                id = recordItem.id.toString(),
-                image = recordItem.imageUri?.let { ImageDto(originalName = it, uploadedLink = it, shortLink = it) },
-                city = City.findCity(recordItem.locationId!!).run { CityDto(id = id, name = name) },
-                provinceId = recordItem.provinceId!!
-            )
-        }
+        return recordDao.getRecordListInCityGroup(cityGroupId, perPage = perPage, pageIdx = offset)
+            .getSingleItemPerId()
+            .map { recordItem ->
+                DiaryItemDto(
+                    id = recordItem.id.toString(),
+                    image = recordItem.fileUri?.let { ImageDto(originalName = it, uploadedLink = it, shortLink = it) },
+                    city = City.findCity(recordItem.locationId!!).run { CityDto(id = id, name = name) },
+                    provinceId = recordItem.provinceId!!
+                )
+            }
     }
 
     override suspend fun uploadDiaryAndGetId(diaryWriteData: DiaryWriteData): String {

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
@@ -2,6 +2,7 @@ package com.strayalphaca.travel_diary.data.map.data_source
 
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
+import com.strayalphaca.travel_diary.core.data.room.model.getSingleItemPerId
 import com.strayalphaca.travel_diary.map.model.City
 import com.strayalphaca.travel_diary.map.model.Location
 import com.strayalphaca.travel_diary.map.model.LocationDiary
@@ -13,11 +14,14 @@ class MapLocalDataSource @Inject constructor(
     private val recordDao: RecordDao
 ) : MapDataSource {
     override suspend fun getDiaryListInNationWide(): BaseResponse<List<LocationDiary>> {
-        val recordItemList = recordDao.getRecordInMapNationWide().groupBy { it.provinceId }.values.firstOrNull()
+        val recordItemList = recordDao.getRecordInMapNationWide()
+            .getSingleItemPerId()
+            .groupBy { it.provinceId }.values
+            .firstOrNull()
 
         val response = recordItemList?.map { recordItem ->
             LocationDiary(
-                thumbnailUri = recordItem.imageUri,
+                thumbnailUri = recordItem.fileUri,
                 location = Location.getInstanceByProvinceId(recordItem.provinceId!!),
                 id = recordItem.id.toString()
             )
@@ -26,11 +30,14 @@ class MapLocalDataSource @Inject constructor(
     }
 
     override suspend fun getDiaryListInProvince(provinceId: Int): BaseResponse<List<LocationDiary>> {
-        val recordItemList = recordDao.getRecordInMapProvince(provinceId).groupBy { it.cityGroupId }.values.firstOrNull()
+        val recordItemList = recordDao.getRecordInMapProvince(provinceId)
+            .getSingleItemPerId()
+            .groupBy { it.cityGroupId }.values
+            .firstOrNull()
 
         val response = recordItemList?.map { recordItem ->
             LocationDiary(
-                thumbnailUri = recordItem.imageUri,
+                thumbnailUri = recordItem.fileUri,
                 location = Location(
                     id = LocationId(recordItem.cityGroupId!!),
                     name = City.getGroupName(recordItem.provinceId!!),


### PR DESCRIPTION
- Room 사용시 음성 파일과 이미지를 모두 추가한 일지의 경우, query를 통해 일지 리스트를 불러오는 과정에서 해당 일지가 리스트 내 중복되어서 존재하는 문제가 발생해 아래 과정을 통해 수정
  - Room에서 일지 리스트 조회시 리턴 데이터 형식인 RecordItem에서 일지의 파일 타입까지 같이 리턴되도록 fileType 변수 추가
  - RecordItem의 companion object에 Comparator<RecordItem> 정의, 기준은 아래와 같다. (왼쪽이 우선순위 높음)
    - 이미지 보유 > 음성 파일 보유 > 파일 없음
  - Comparator를 사용해 정렬한 후, 가장 앞의 원소만을 가져오도록 하여 일지가 하나만 남겨지도록 구현하여 중복 문제 해결