### PR TITLE
Fix File

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/FileModule.kt
@@ -10,6 +10,8 @@ import com.strayalphaca.travel_diary.domain.auth.repository.AuthRepository
 import com.strayalphaca.travel_diary.domain.file.model.FileResizeHandler
 import com.strayalphaca.travel_diary.domain.file.repository.FileRepository
 import com.strayalphaca.travel_diary.core.presentation.model.IS_LOCAL
+import com.strayalphaca.travel_diary.data.file.file_manager.ExternalFileManager
+import com.strayalphaca.travel_diary.data.file.file_manager.FileManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,12 +26,13 @@ object FileModule {
     fun provideFileRepository(
         @BaseClient retrofit: Retrofit,
         authRepository: AuthRepository,
-        recordDao: RecordDao
+        recordDao: RecordDao,
+        fileManager: FileManager
     ) : FileRepository {
         val hasToken = authRepository.getAccessToken() != null
         return if (hasToken) {
             if (IS_LOCAL) {
-                LocalFileRepository(recordDao)
+                LocalFileRepository(recordDao, fileManager)
             } else {
                 RemoteFileRepository(retrofit)
             }
@@ -43,5 +46,12 @@ object FileModule {
         @ApplicationContext context: Context
     ) : FileResizeHandler {
         return FileResizeHandlerImpl(context)
+    }
+
+    @Provides
+    fun provideFileManager(
+        @ApplicationContext context : Context
+    ) : FileManager {
+        return ExternalFileManager(context)
     }
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/ExternalFileManager.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/ExternalFileManager.kt
@@ -1,0 +1,69 @@
+package com.strayalphaca.travel_diary.data.file.file_manager
+
+import android.content.Context
+import android.os.Environment
+import androidx.core.net.toUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+
+class ExternalFileManager constructor(
+    private val context : Context
+) : FileManager {
+    override suspend fun saveFileAndGetPath(file: File): String? = withContext(Dispatchers.IO) {
+        if (!isExternalStorageWritable()) return@withContext null
+
+        val fileName = file.name
+        val externalStorageDir = context.getExternalFilesDir(null)
+        val fileDirPath = externalStorageDir?.absolutePath + File.separator + "medias"
+        val filePath = fileDirPath + File.separator + fileName
+
+        File(fileDirPath).run {
+            if (!exists()) {
+                if (!mkdir()) return@withContext null
+            }
+        }
+
+        val inputStream = try {
+            context.contentResolver.openInputStream(fixContentFilePath(file.path).toUri()) ?: return@withContext null
+        } catch (e : FileNotFoundException) {
+            FileInputStream(file)
+        }
+        val outputStream = FileOutputStream(filePath)
+        val buffer = ByteArray(1024)
+        var length : Int
+        while (inputStream.read(buffer).also { length = it } > 0) {
+            outputStream.write(buffer, 0, length)
+        }
+
+        outputStream.flush()
+        outputStream.close()
+        inputStream.close()
+        return@withContext filePath
+    }
+
+    override suspend fun deleteFile(filePath: String): Boolean {
+        val file = File(filePath)
+        return if (file.exists()) {
+            file.delete()
+        } else {
+            false
+        }
+    }
+
+    private fun isExternalStorageWritable() : Boolean {
+        val state = Environment.getExternalStorageState()
+        return Environment.MEDIA_MOUNTED == state
+    }
+
+    private fun fixContentFilePath(path : String) : String {
+        return if (path.contains("content:/") && !path.contains("content://")){
+            path.replace("content:/", "content://")
+        } else {
+            path
+        }
+    }
+}

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/FileManager.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/FileManager.kt
@@ -1,0 +1,8 @@
+package com.strayalphaca.travel_diary.data.file.file_manager
+
+import java.io.File
+
+interface FileManager {
+    suspend fun saveFileAndGetPath(file : File) : String?
+    suspend fun deleteFile(filePath : String) : Boolean
+}

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/LocalFileRepository.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/repository/LocalFileRepository.kt
@@ -4,17 +4,22 @@ import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalpaca.travel_diary.core.domain.model.DiaryDate
 import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
 import com.strayalphaca.travel_diary.core.data.room.entity.FileEntity
+import com.strayalphaca.travel_diary.data.file.file_manager.FileManager
 import com.strayalphaca.travel_diary.domain.file.model.FileInfo
 import com.strayalphaca.travel_diary.domain.file.repository.FileRepository
 import java.util.Calendar
 
 class LocalFileRepository(
-    private val recordDao: RecordDao
+    private val recordDao: RecordDao,
+    private val fileManager: FileManager
 ) : FileRepository {
     override suspend fun uploadFile(fileInfo: FileInfo): BaseResponse<String> {
+        val path = fileManager.saveFileAndGetPath(fileInfo.file)
+            ?: return BaseResponse.Failure(errorCode = -1, errorMessage = "error invoked when save file to external storage")
+
         val response = recordDao.addFile(FileEntity(
             type = fileInfo.fileType.toString(),
-            filePath = fileInfo.file.path.toString(),
+            filePath = path,
             createdAt = DiaryDate.getInstanceFromCalendar(Calendar.getInstance()).toString()
         ))
         return BaseResponse.Success(data = response.toString())


### PR DESCRIPTION
Room 사용 버젼에서 원본 이미지/파일에 접근하는 방식을 사용할 경우, 핸드폰에서 해당 파일을 제거했을 때 파일을 정상적으로 불러오지 못하는 문제가 발생하여, path를 통해 원본 이미지/파일에 접근하는 방식 대신, 파일을 external Storage에 저장하여 해당 파일을 사용하도록 구현
- 파일을 로컬에 저장하는 로직을 선언한 FileManager 인터페이스 정의
- ExternalStorage에 파일을 저장/삭제하는 ExternalFileManager 구현체 정의

단, 파일 수정시 fileManager에 접근해서 더 이상 사용하지 않는 파일에 대해서는 제거해주는 작업이 필요하며, 해당 작업은 diary쪽에서 수행할 예정