### PR TITLE
Fix diary

### DIFF
--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/model/ResponseData.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/model/ResponseData.kt
@@ -27,6 +27,7 @@ data class DiaryDto(
 }
 
 data class VoiceFileInDiaryDto(
+    val id : String = "",
     val originName : String,
     val uploadedLink : String = "",
     val shortLink : String? = null

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
@@ -26,5 +26,6 @@ data class RecordItem(
 fun List<RecordItem>.getSingleItemPerId() : List<RecordItem> {
     return this.groupBy { it.id }
         .map { it.value.sortedWith(RecordItem.recordItemComparatorOnSameId).first() }
+        .map { if (it.fileType == "Voice") it.copy(fileUri = null) else it } // 일지 아이템에서는 음성 파일 링크는 사용되지 않으므로 null로 변경
         .sortedBy { it.date }
 }

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryLocalDataSource.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryLocalDataSource.kt
@@ -30,7 +30,7 @@ class DiaryLocalDataSource @Inject constructor(
             weather = recordEntity.weather,
             content = recordEntity.content,
             medias = fileList.filter { it.type == "Image" || it.type == "Video" },
-            voice = fileList.find { it.type == "Voice" }?.let { VoiceFileInDiaryDto(originName = it.originName, uploadedLink = it.uploadedLink, shortLink = it.shortLink) },
+            voice = fileList.find { it.type == "Voice" }?.let { VoiceFileInDiaryDto(id = it.id, originName = it.originName, uploadedLink = it.uploadedLink, shortLink = it.shortLink) },
             cityId = recordEntity.locationId,
             createdAt = recordEntity.createdAt
         )

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryTestDataSource.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/data_source/DiaryTestDataSource.kt
@@ -44,7 +44,7 @@ class DiaryTestDataSource @Inject constructor(
                 weather = weather.toString(),
                 content = content,
                 medias = medias?.map { MediaFileInfoDto(id = it, originName = it, uploadedLink = it, thumbnailLink = it) } ?: emptyList(),
-                voice = voice?.let { VoiceFileInDiaryDto(it, it, null) },
+                voice = voice?.let { VoiceFileInDiaryDto(id = "", it, it, null) },
                 createdAt = "",
                 cityId = cityId,
                 place = null
@@ -62,7 +62,7 @@ class DiaryTestDataSource @Inject constructor(
                 weather = weather.toString(),
                 content = content ?: "-",
                 medias = medias?.map { MediaFileInfoDto(id = it, originName = it, uploadedLink = it, thumbnailLink = it) } ?: emptyList(),
-                voice = voice?.let { VoiceFileInDiaryDto(it, it, null) },
+                voice = voice?.let { VoiceFileInDiaryDto(id = "", it, it, null) },
                 createdAt = "",
                 cityId = cityId,
                 place = cityName

--- a/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
+++ b/data/diary/src/main/java/com/strayalphaca/travel_diary/data/diary/utils/Mapper.kt
@@ -78,7 +78,7 @@ fun mediaFileInfoDtoToFile(fileDto: MediaFileInfoDto) : File {
 
 fun voiceFileInFileDtoToFile(voiceFileInDiaryDto: VoiceFileInDiaryDto) : File {
     return File(
-        id = voiceFileInDiaryDto.originName,
+        id = voiceFileInDiaryDto.id,
         fileLink = voiceFileInDiaryDto.uploadedLink,
         type = FileType.VOICE,
         thumbnailLink = null

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/block/SoundView.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/block/SoundView.kt
@@ -9,11 +9,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import com.strayalphaca.presentation.R
 import com.strayalphaca.presentation.components.atom.base_icon_button.BaseIconButton
+import com.strayalphaca.presentation.ui.theme.Gray4
 
 @Composable
 fun SoundView(
@@ -23,7 +25,8 @@ fun SoundView(
     pause : () -> Unit = {},
     remove : (() -> Unit)? = null,
     soundProgressChange : (Float) -> Unit = {},
-    soundProgress : Float = 0f
+    soundProgress : Float = 0f,
+    isError : Boolean = false
 ) {
 
     Box(modifier = Modifier.fillMaxWidth()) {
@@ -43,16 +46,18 @@ fun SoundView(
                     Text(modifier = Modifier.padding(start = 12.dp), text = stringResource(id = R.string.recording_file), style = MaterialTheme.typography.body2)
 
                     Row {
-                        if (playing) {
-                            BaseIconButton(
-                                iconResourceId = R.drawable.ic_pause,
-                                onClick = pause
-                            )
-                        } else {
-                            BaseIconButton(
-                                iconResourceId = R.drawable.ic_play_arrow,
-                                onClick = play
-                            )
+                        if (!isError) {
+                            if (playing) {
+                                BaseIconButton(
+                                    iconResourceId = R.drawable.ic_pause,
+                                    onClick = pause
+                                )
+                            } else {
+                                BaseIconButton(
+                                    iconResourceId = R.drawable.ic_play_arrow,
+                                    onClick = play
+                                )
+                            }
                         }
 
                         Spacer(modifier = Modifier.width(12.dp))
@@ -68,16 +73,26 @@ fun SoundView(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                Slider(
-                    value = soundProgress,
-                    onValueChange = {
-                        soundProgressChange(it)
-                    },
-                    colors = SliderDefaults.colors(
-                        thumbColor = MaterialTheme.colors.onBackground,
-                        activeTrackColor = MaterialTheme.colors.onBackground
+                if (isError) {
+                    Text(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                        textAlign = TextAlign.Center,
+                        color = Gray4,
+                        style = MaterialTheme.typography.caption,
+                        text = "음성파일 로드 중 문제가 발생했습니다."
                     )
-                )
+                } else {
+                    Slider(
+                        value = soundProgress,
+                        onValueChange = {
+                            soundProgressChange(it)
+                        },
+                        colors = SliderDefaults.colors(
+                            thumbColor = MaterialTheme.colors.onBackground,
+                            activeTrackColor = MaterialTheme.colors.onBackground
+                        )
+                    )
+                }
             }
         }
     }
@@ -95,7 +110,7 @@ fun SoundView(
 fun SoundViewPreview() {
     TravelDiaryTheme {
         Surface(modifier = Modifier.padding(16.dp)) {
-            SoundView(Uri.EMPTY)
+            SoundView(Uri.EMPTY, isError = true)
         }
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -267,7 +267,8 @@ fun DiaryDetailScreen(
                                 play = playMusic,
                                 pause = pauseMusic,
                                 soundProgressChange = changeMusicProgress,
-                                soundProgress = musicProgress
+                                soundProgress = musicProgress,
+                                isError = state.musicError
                             )
                         }
                     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/detail/DiaryDetailScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
 import com.strayalphaca.travel_diary.diary.model.DiaryDetail
 import com.strayalphaca.travel_diary.diary.model.Feeling
 import com.strayalphaca.travel_diary.diary.model.File
@@ -49,6 +50,7 @@ import com.strayalphaca.presentation.screens.diary.component.block.LocationView
 import com.strayalphaca.presentation.screens.diary.component.block.WeatherFeelingSelectView
 import com.strayalphaca.presentation.screens.diary.component.template.DiaryViewTemplate
 import com.strayalphaca.presentation.utils.collectAsEffect
+import com.strayalphaca.presentation.utils.rememberLifecycleEvent
 import com.strayalphaca.presentation.utils.thenIf
 import com.strayalphaca.travel_diary.diary.model.Weather
 import kotlin.math.absoluteValue
@@ -66,10 +68,17 @@ fun DiaryDetailContainer(
     val state by viewModel.state.collectAsState()
     val musicProgress by viewModel.musicProgress.collectAsState()
     val context = LocalContext.current
+    val lifecycleEvent = rememberLifecycleEvent()
 
     LaunchedEffect(needRefresh) {
         if (needRefresh)
             viewModel.tryRefresh()
+    }
+
+    LaunchedEffect(lifecycleEvent) {
+        if (lifecycleEvent == Lifecycle.Event.ON_STOP || lifecycleEvent == Lifecycle.Event.ON_PAUSE) {
+            viewModel.pauseMusic()
+        }
     }
 
     viewModel.goBackNavigationEvent.collectAsEffect { deleteSuccess ->

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/MusicPlayerImpl.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/model/MusicPlayerImpl.kt
@@ -27,6 +27,7 @@ class MusicPlayerImpl @Inject constructor(private val context : Context) : Music
                 .setUsage(AudioAttributes.USAGE_MEDIA)
                 .build()
         )
+        mediaPlayer.reset()
         if (isLocal) {
             val changedUri = fixContentUrl(uri)
             mediaPlayer.setDataSource(context, changedUri)
@@ -61,7 +62,8 @@ class MusicPlayerImpl @Inject constructor(private val context : Context) : Music
     }
 
     override fun release() {
-        mediaPlayer.stop()
+        if (mediaPlayer.isPlaying)
+            mediaPlayer.stop()
         mediaPlayer.release()
     }
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
@@ -103,6 +104,11 @@ class DiaryWriteViewModel @Inject constructor(
             if (response is BaseResponse.Success) {
                 inputContent(response.data.content)
                 events.send(DiaryWriteEvent.DiaryLoadingSuccess(response.data))
+                try {
+                    response.data.voiceFile?.fileLink?.let { musicPlayer.setMusic(it.toUri(), IS_LOCAL) }
+                } catch (e : IOException) {
+                    events.send(DiaryWriteEvent.MusicLoadingFail)
+                }
             } else {
                 events.send(DiaryWriteEvent.DiaryLoadingFail)
             }
@@ -122,8 +128,12 @@ class DiaryWriteViewModel @Inject constructor(
                 return@launch
             }
 
-            musicPlayer.setMusic(file, isLocal)
-            events.send(DiaryWriteEvent.AddVoiceFile(file))
+            try {
+                musicPlayer.setMusic(file, isLocal)
+                events.send(DiaryWriteEvent.AddVoiceFile(file))
+            } catch (e : IOException) {
+                events.send(DiaryWriteEvent.MusicLoadingFail)
+            }
         }
     }
 
@@ -370,7 +380,6 @@ class DiaryWriteViewModel @Inject constructor(
                 state.copy(buttonActive = true, showLoadingError = true, showInitLoading = false)
             }
             is DiaryWriteEvent.DiaryLoadingSuccess -> {
-                events.diaryDetail.voiceFile?.fileLink?.let { musicPlayer.setMusic(it.toUri(), IS_LOCAL) }
                 state.copy(
                     buttonActive = true,
                     showLoadingError = false,
@@ -397,10 +406,10 @@ class DiaryWriteViewModel @Inject constructor(
                 state.copy(buttonActive = true)
             }
             is DiaryWriteEvent.AddVoiceFile -> {
-                state.copy(voiceFile = MediaFileInDiary.LocalFile(localUri = events.file, fileType = FileType.Voice))
+                state.copy(voiceFile = MediaFileInDiary.LocalFile(localUri = events.file, fileType = FileType.Voice), musicError = false)
             }
             DiaryWriteEvent.RemoveVoiceFile -> {
-                state.copy(voiceFile = null)
+                state.copy(voiceFile = null, musicError = false)
             }
             is DiaryWriteEvent.AddImageList -> {
                 val newImages = events.file.map { MediaFileInDiary.LocalFile(localUri = it, fileType = uriHandler.getFileType(it)) }
@@ -450,6 +459,9 @@ class DiaryWriteViewModel @Inject constructor(
                     diaryDate = events.diaryDate
                 )
             }
+            DiaryWriteEvent.MusicLoadingFail -> {
+                state.copy(musicError = true)
+            }
         }
     }
 
@@ -477,6 +489,7 @@ sealed class DiaryWriteEvent {
     class SelectLocationById(val cityId : Int) : DiaryWriteEvent()
     object ClearLocation : DiaryWriteEvent()
     class SetDiaryDate(val diaryDate: DiaryDate) : DiaryWriteEvent()
+    object MusicLoadingFail : DiaryWriteEvent()
 }
 
 data class DiaryWriteState(
@@ -492,5 +505,6 @@ data class DiaryWriteState(
     val showLocationPickerDialog : Boolean = false,
     val cityName : String ?= null,
     val cityId : Int ?= null,
-    val diaryDate: DiaryDate = DiaryDate.getInstanceFromCalendar()
+    val diaryDate: DiaryDate = DiaryDate.getInstanceFromCalendar(),
+    val musicError : Boolean = false
 )

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -96,6 +96,8 @@ class DiaryWriteViewModel @Inject constructor(
     }
 
     fun tryLoadDetail(id : String) {
+        if (diaryId == id) return
+
         diaryId = id
         viewModelScope.launch {
             events.send(DiaryWriteEvent.DiaryLoading)

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -308,7 +308,8 @@ fun DiaryWriteScreen(
                                 pause = pauseMusic,
                                 remove = removeVoiceFile,
                                 soundProgressChange = changeMusicProgress,
-                                soundProgress = musicProgress
+                                soundProgress = musicProgress,
+                                isError = state.musicError
                             )
                         } else {
                             EmptySoundView(

--- a/presentation/src/main/java/com/strayalphaca/presentation/utils/rememberLifecycleEvent.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/utils/rememberLifecycleEvent.kt
@@ -1,0 +1,27 @@
+package com.strayalphaca.presentation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+
+@Composable
+fun rememberLifecycleEvent(lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current) : Lifecycle.Event {
+    var state by remember { mutableStateOf(Lifecycle.Event.ON_ANY) }
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            state = event
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+    return state
+}


### PR DESCRIPTION
- 일지 수정 화면에서 confiuration change 발생시 다시 일지 데이터를 로드하는 현상으로 인해 수정한 내용이 이전 내용으로 덮어지는 문제 수정
- 일지 상세 화면에서 음성 파일이 재생된 상태인 경우 홈 버튼 클릭 및 타 화면 이동시 재생중인 음성이 중지되도록 수정
- 음악 재생 UI의 에러 상태 UI 추가
- 달력/지도/일지 목록 화면에서 음성 파일만 존재하는 경우, 기본 이미지가 표시되지 않던 문제 수정
