### PR TITLE
Fix setting

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/di/LoginModule.kt
@@ -6,7 +6,7 @@ import com.strayalphaca.presentation.models.error_code_mapper.DefaultErrorCodeMa
 import com.strayalphaca.presentation.models.error_code_mapper.login.AuthCodeErrorCodeMapper
 import com.strayalphaca.presentation.models.error_code_mapper.login.LoginErrorCodeMapper
 import com.strayalphaca.presentation.models.error_code_mapper.login.SignupErrorCodeMapper
-import com.strayalphaca.travel_diary.core.data.room.database.TrailyRoomDatabase
+import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
 import com.strayalphaca.travel_diary.data.login.data_source.LoginDataSource
 import com.strayalphaca.travel_diary.data.login.data_source.LoginLocalDataSource
 import com.strayalphaca.travel_diary.data.login.repository_impl.LoginRepositoryImpl
@@ -44,9 +44,9 @@ object LoginModule {
     @Singleton
     @Provides
     fun provideLoginDataSource(
-        trailyRoomDatabase: TrailyRoomDatabase
+        recordDao: RecordDao
     ) : LoginDataSource {
-        return LoginLocalDataSource(trailyRoomDatabase)
+        return LoginLocalDataSource(recordDao)
     }
 
     @LoginErrorCodeMapperProvide

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import com.strayalphaca.travel_diary.core.data.room.entity.FileEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.LocationEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordEntity
@@ -114,4 +115,16 @@ interface RecordDao {
 
     @Query("SELECT * FROM LocationEntity")
     suspend fun getLocations() : List<LocationEntity>
+
+    @Query("DELETE FROM RecordEntity")
+    suspend fun clearRecord()
+
+    @Query("DELETE FROM RecordFileEntity")
+    suspend fun clearRecordFile()
+
+    @Transaction
+    suspend fun clearData() {
+        clearRecord()
+        clearRecordFile()
+    }
 }

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import androidx.room.Transaction
 import com.strayalphaca.travel_diary.core.data.room.entity.FileEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.LocationEntity
 import com.strayalphaca.travel_diary.core.data.room.entity.RecordEntity
@@ -118,13 +117,4 @@ interface RecordDao {
 
     @Query("DELETE FROM RecordEntity")
     suspend fun clearRecord()
-
-    @Query("DELETE FROM RecordFileEntity")
-    suspend fun clearRecordFile()
-
-    @Transaction
-    suspend fun clearData() {
-        clearRecord()
-        clearRecordFile()
-    }
 }

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/data_source/LoginLocalDataSource.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/data_source/LoginLocalDataSource.kt
@@ -34,7 +34,7 @@ class LoginLocalDataSource @Inject constructor(
 
     override suspend fun deleteUser(): BaseResponse<Nothing> {
         withContext(Dispatchers.IO) {
-            recordDao.clearData()
+            recordDao.clearRecord()
         }
         return BaseResponse.EmptySuccess
     }

--- a/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/data_source/LoginLocalDataSource.kt
+++ b/data/login/src/main/java/com/strayalphaca/travel_diary/data/login/data_source/LoginLocalDataSource.kt
@@ -1,14 +1,16 @@
 package com.strayalphaca.travel_diary.data.login.data_source
 
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
-import com.strayalphaca.travel_diary.core.data.room.database.TrailyRoomDatabase
+import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
 import com.strayalphaca.travel_diary.data.login.model.TokensDto
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Singleton
 
+@Singleton
 class LoginLocalDataSource @Inject constructor(
-    private val trailyRoomDatabase: TrailyRoomDatabase
+    private val recordDao: RecordDao
 ) : LoginDataSource {
     override suspend fun postSignup(): BaseResponse<String> {
         return BaseResponse.Failure(errorCode = -1, errorMessage = "-")
@@ -32,7 +34,7 @@ class LoginLocalDataSource @Inject constructor(
 
     override suspend fun deleteUser(): BaseResponse<Nothing> {
         withContext(Dispatchers.IO) {
-            trailyRoomDatabase.clearAllTables()
+            recordDao.clearData()
         }
         return BaseResponse.EmptySuccess
     }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/SettingsDestinations.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/settings/SettingsDestinations.kt
@@ -1,6 +1,7 @@
 package com.strayalphaca.presentation.screens.settings
 
 import com.strayalphaca.presentation.R
+import com.strayalphaca.travel_diary.core.presentation.model.IS_LOCAL
 
 interface SettingsDestinations {
     val route : String
@@ -29,7 +30,7 @@ object ScreenLockScreenDestination : SettingsDestinations {
 
 object WithdrawalScreenDestination : SettingsDestinations {
     override val route: String = "withdrawal"
-    override val titleStringId : Int = R.string.withdrawal
+    override val titleStringId : Int = if (IS_LOCAL) R.string.clear_data else R.string.withdrawal
 }
 
 object ChangePasswordScreenDestination : SettingsDestinations {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -129,5 +129,5 @@
     <string name="input_exist_screen_password_title">기존 비밀번호 입력</string>
     <string name="password_not_macthed">비밀번호가 일치하지 않습니다.</string>
     <string name="move_back">돌아가기</string>
-    <string name="clear_data">데이터 초기화하기</string>
+    <string name="clear_data">데이터 초기화</string>
 </resources>


### PR DESCRIPTION
- 데이터 초기화 화면에서 타이틀이 "회원탈퇴"로 되어있던 부분을 "데이터 초기화"로 변경
- 데이터 초기화시 recordEntity 테이블의 데이터만 초기화하도록 수정
  - 파일을 제거하는 작업은 추후 workManager를 통해 수행할 예정이며, 이 workManager에서 recordFileEntity와 fileEntity를 가지고 제거할  파일을 조회할 예정