### PR TITLE
fix room

### DIFF
--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/entity/RecordFileEntity.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/entity/RecordFileEntity.kt
@@ -1,10 +1,29 @@
 package com.strayalphaca.travel_diary.core.data.room.entity
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.PrimaryKey
 
-@Entity(primaryKeys = ["recordId", "fileId"])
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = RecordEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["recordId"],
+            onDelete = ForeignKey.SET_NULL
+        ),
+        ForeignKey(
+            entity = FileEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["fileId"],
+            onDelete = ForeignKey.CASCADE
+        ),
+    ]
+)
 data class RecordFileEntity(
-    val recordId : Int,
+    val recordId : Int?,
     val fileId : Int,
     val positionInRecord : Int
-)
+) {
+    @PrimaryKey(autoGenerate = true) var id : Int = 0
+}


### PR DESCRIPTION
- recordFileEntity의 recordId, fileId를 foreignKey로 변경 및 autuGenerate id 추가
  - recordId의 경우, 해당 일지가 제거되면 null로 전환
  - fileId는 cascade로 설정하여, 원본 파일이 제거되면 같이 제거됨