### PR TITLE
Fearue file clear

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     implementation libs.hilt
     kapt libs.hilt.compiler
     implementation libs.hilt.navigation.compose
+    implementation libs.hilt.worker
+    kapt libs.hilt.worker.compiler
 
     // android compose
     implementation libs.androidx.compose.ui
@@ -126,6 +128,9 @@ dependencies {
 
     // kotlin reflection
     implementation libs.kotlin.reflection
+
+    // workManager
+    implementation libs.workruntime.ktx
 }
 
 kapt {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -48,6 +48,17 @@
             </intent-filter>
         </receiver>
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:minSdkVersion="33"/>
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/strayalphaca/travel_diary/BaseApplication.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/BaseApplication.kt
@@ -12,6 +12,7 @@ import com.google.firebase.analytics.analytics
 import com.strayalphaca.presentation.alarm.NotificationManager
 import com.strayalphaca.presentation.models.NotificationChannelInfo
 import com.strayalphaca.travel_diary.core.presentation.logger.LoggerLibManager
+import com.strayalphaca.travel_diary.data.file.file_cleaner.FileCleanerWorker
 import dagger.hilt.android.HiltAndroidApp
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject

--- a/app/src/main/java/com/strayalphaca/travel_diary/BaseApplication.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/BaseApplication.kt
@@ -1,6 +1,11 @@
 package com.strayalphaca.travel_diary
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.analytics
@@ -8,12 +13,14 @@ import com.strayalphaca.presentation.alarm.NotificationManager
 import com.strayalphaca.presentation.models.NotificationChannelInfo
 import com.strayalphaca.travel_diary.core.presentation.logger.LoggerLibManager
 import dagger.hilt.android.HiltAndroidApp
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 
 @HiltAndroidApp
-class BaseApplication : Application() {
+class BaseApplication : Application(), Configuration.Provider {
     private lateinit var firebaseAnalytics: FirebaseAnalytics
     @Inject lateinit var loggerLibManager: LoggerLibManager<FirebaseAnalytics>
+    @Inject lateinit var workerFactory : HiltWorkerFactory
 
     override fun onCreate() {
         super.onCreate()
@@ -21,5 +28,24 @@ class BaseApplication : Application() {
         firebaseAnalytics = Firebase.analytics
         loggerLibManager.attachLogger(firebaseAnalytics)
         NotificationManager().initNotificationChannel(baseContext, NotificationChannelInfo.DailyNotification)
+
+        setFileCleanerWorker()
+    }
+
+    override fun getWorkManagerConfiguration(): Configuration {
+        return Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
+    }
+
+    private fun setFileCleanerWorker() {
+        val fileClearWorkRequest = PeriodicWorkRequestBuilder<FileCleanerWorker>(24, TimeUnit.HOURS)
+            .build()
+
+        WorkManager.getInstance(this).enqueueUniquePeriodicWork(
+            "localFileCleaner",
+            ExistingPeriodicWorkPolicy.KEEP,
+            fileClearWorkRequest
+        )
     }
 }

--- a/app/src/main/java/com/strayalphaca/travel_diary/FileCleanerWorker.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/FileCleanerWorker.kt
@@ -1,0 +1,31 @@
+package com.strayalphaca.travel_diary
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.strayalphaca.travel_diary.core.data.room.dao.RecordDao
+import com.strayalphaca.travel_diary.data.file.file_manager.FileManager
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class FileCleanerWorker @AssistedInject constructor(
+    @Assisted appContext : Context,
+    @Assisted workerParams : WorkerParameters,
+    private val fileManager: FileManager,
+    private val recordDao: RecordDao
+) : CoroutineWorker(appContext, workerParams) {
+    override suspend fun doWork(): Result {
+        recordDao
+            .getDeleteTargetFilePaths()
+            .also {  paths ->
+                recordDao.deleteFile(paths)
+            }
+            .map { path ->
+                fileManager.deleteFile(path)
+            }
+        return Result.success()
+    }
+
+}

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
@@ -117,4 +117,15 @@ interface RecordDao {
 
     @Query("DELETE FROM RecordEntity")
     suspend fun clearRecord()
+
+    @Query(
+        "SELECT f.filePath FROM FileEntity as f " +
+        "INNER JOIN RecordFileEntity as rf " +
+        "WHERE rf.recordId is null"
+    )
+    suspend fun getDeleteTargetFilePaths() : List<String>
+
+    @Query("DELETE FROM FileEntity WHERE filePath IN (:filePaths)")
+    suspend fun deleteFile(filePaths : List<String>)
+
 }

--- a/data/file/build.gradle
+++ b/data/file/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'com.google.dagger.hilt.android'
 }
 
 android {
@@ -50,4 +52,13 @@ dependencies {
 
     // retrofit2 https://github.com/square/retrofit
     implementation libs.bundles.retrofit2
+
+    // hilt
+    implementation libs.hilt
+    kapt libs.hilt.compiler
+    implementation libs.hilt.worker
+    kapt libs.hilt.worker.compiler
+
+    // workManager
+    implementation libs.workruntime.ktx
 }

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_cleaner/FileCleanerWorker.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_cleaner/FileCleanerWorker.kt
@@ -1,4 +1,4 @@
-package com.strayalphaca.travel_diary
+package com.strayalphaca.travel_diary.data.file.file_cleaner
 
 import android.content.Context
 import androidx.hilt.work.HiltWorker

--- a/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/ExternalFileManager.kt
+++ b/data/file/src/main/java/com/strayalphaca/travel_diary/data/file/file_manager/ExternalFileManager.kt
@@ -9,6 +9,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.FileOutputStream
+import java.util.Calendar
 
 class ExternalFileManager constructor(
     private val context : Context
@@ -16,7 +17,7 @@ class ExternalFileManager constructor(
     override suspend fun saveFileAndGetPath(file: File): String? = withContext(Dispatchers.IO) {
         if (!isExternalStorageWritable()) return@withContext null
 
-        val fileName = file.name
+        val fileName = getCurrentTimeString() + "_" + file.name
         val externalStorageDir = context.getExternalFilesDir(null)
         val fileDirPath = externalStorageDir?.absolutePath + File.separator + "medias"
         val filePath = fileDirPath + File.separator + fileName
@@ -64,6 +65,19 @@ class ExternalFileManager constructor(
             path.replace("content:/", "content://")
         } else {
             path
+        }
+    }
+
+    private fun getCurrentTimeString() : String {
+        return Calendar.getInstance().run {
+            val year = get(Calendar.YEAR)
+            val month = get(Calendar.MONTH)
+            val day = get(Calendar.DAY_OF_MONTH)
+            val hour = get(Calendar.HOUR_OF_DAY)
+            val minute = get(Calendar.MINUTE)
+            val second = get(Calendar.SECOND)
+            val milli = get(Calendar.MILLISECOND)
+            "${year}_${month}_${day}_${hour}_${minute}_${second}_$milli"
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ coroutine = "1.7.3"
 exifinterface = "1.3.6"
 firebase_bom = "32.7.0"
 room = "2.5.2"
+work_version = "2.8.0"
 
 [libraries]
 android-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -38,6 +39,8 @@ test-espresso = { group = "androidx.test.espresso", name = "espresso-core", vers
 hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt_compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 hilt_navigation_compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hilt_navigation_compose" }
+hilt_worker = { group = "androidx.hilt", name = "hilt-work", version = "1.0.0" }
+hilt_worker_compiler = { group = "androidx.hilt", name = "hilt-compiler", version = "1.0.0" }
 
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref="compose" }
@@ -94,6 +97,8 @@ roomRuntime = { module = "androidx.room:room-runtime", version.ref = "room" }
 roomKtx = { module = "androidx.room:room-ktx", version.ref = "room" }
 roomCompiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 
+# work manager
+workruntime_ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work_version" }
 
 [bundles]
 okhttp3 = ["okhttp3-okhttp", "okhttp3-logging-interceptor"]


### PR DESCRIPTION
Room 기반 로컬 모드로 사용시 아래 사항을 수정/구현
- 기존 원본 파일 링크를 사용하던 방식에서, external storage에 저장하는 방식으로 수정
  - 이는 원본 파일이 제거된 경우, 정상적으로 불러오지 못하는 현상이 발생하기 때문
  - 이에 android sdk idx 28 이하의 기기에 한해, 이미지/음성 파일을 선택할 때 write_external_storage 권한을 요청하도록 수정
- 파일 제거시 호출할 room dao의 메서드 정의
- 파일을 저장하는 과정에서 파일 이름 앞에 저장 시간을 붙이도록 수정
  - 이는 앱에서 동일한 사진을 여러개 올렸다고 가정했을 시, 동일한 이름을 가진 파일들을 모두 제거하지 않도록 구분하기 위함
- 파일 제거를 수행하는 Worker를 24시간 주기로 동작하도록 하여 더 이상 사용하지 않는 파일을 제거
  - worker, 그리고 worker와 관련된 hilt 라이브러리 추가 세팅
  - worker는 data:file 모듈에 정의되어 있으며, app 모듈의 Application 클래스에서 호출