### PR TITLE
Fix diary

### DIFF
--- a/app/src/main/java/com/strayalphaca/travel_diary/RootViewModel.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/RootViewModel.kt
@@ -2,6 +2,7 @@ package com.strayalphaca.travel_diary
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.strayalpaca.travel_diary.domain.lock.model.LockScreenAvailabilityManager
 import com.strayalpaca.travel_diary.domain.lock.use_case.UseCaseUsePassword
 import com.strayalphaca.presentation.models.deeplink_handler.NotificationDeepLinkHandler
 import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
@@ -17,7 +18,8 @@ class RootViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val deepLinkHandler: NotificationDeepLinkHandler,
     private val useCaseUsePassword: UseCaseUsePassword,
-    private val useCaseSaveToken: UseCaseSaveToken
+    private val useCaseSaveToken: UseCaseSaveToken,
+    private val lockScreenAvailabilityManager: LockScreenAvailabilityManager
 ) : ViewModel() {
     val invalidRefreshToken = authRepository.invalidRefreshToken()
 
@@ -34,6 +36,11 @@ class RootViewModel @Inject constructor(
         viewModelScope.launch {
             if (authRepository.getAccessToken() == null || !useCaseUsePassword())
                 return@launch
+
+            if (!lockScreenAvailabilityManager.lockScreenEnabled) {
+                lockScreenAvailabilityManager.enableLockScreen()
+                return@launch
+            }
 
             _showLockScreen.emit(true)
         }

--- a/domain/lock/src/main/java/com/strayalpaca/travel_diary/domain/lock/model/LockScreenAvailabilityManager.kt
+++ b/domain/lock/src/main/java/com/strayalpaca/travel_diary/domain/lock/model/LockScreenAvailabilityManager.kt
@@ -1,0 +1,17 @@
+package com.strayalpaca.travel_diary.domain.lock.model
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class LockScreenAvailabilityManager @Inject constructor() {
+    var lockScreenEnabled : Boolean = true
+
+    fun disableLockScreen() {
+        lockScreenEnabled = false
+    }
+
+    fun enableLockScreen() {
+        lockScreenEnabled = true
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.strayalpaca.travel_diary.core.domain.model.DiaryDate
 import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
+import com.strayalpaca.travel_diary.domain.lock.model.LockScreenAvailabilityManager
 import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
 import com.strayalphaca.presentation.models.event_flow.asEventFlow
 import com.strayalphaca.presentation.screens.diary.model.CurrentShowSelectView
@@ -57,7 +58,8 @@ class DiaryWriteViewModel @Inject constructor(
     private val musicPlayer: MusicPlayer,
     private val uriHandler: UriHandler,
     private val fileResizeHandler: FileResizeHandler,
-    private val userEventLogger: UserEventLogger
+    private val userEventLogger: UserEventLogger,
+    private val lockScreenAvailabilityManager: LockScreenAvailabilityManager
 ) : ViewModel() {
     private val events = Channel<DiaryWriteEvent>()
     val state: StateFlow<DiaryWriteState> = events.receiveAsFlow()
@@ -382,6 +384,10 @@ class DiaryWriteViewModel @Inject constructor(
     private fun releaseMusicPlayer() {
         musicPlayerJob?.cancel()
         musicPlayer.release()
+    }
+
+    fun disableLockScreen() {
+        lockScreenAvailabilityManager.disableLockScreen()
     }
 
     private fun reduce(state: DiaryWriteState, events: DiaryWriteEvent): DiaryWriteState {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -80,6 +80,9 @@ class DiaryWriteViewModel @Inject constructor(
     private val _toastMessage = MutableEventFlow<String>()
     val toastMessage = _toastMessage.asEventFlow()
 
+    private val _requestPermissionSettingAction = MutableStateFlow<String?>(null)
+    val requestPermissionSettingAction = _requestPermissionSettingAction.asStateFlow()
+
     init {
         musicPlayer.setCompleteCallback {
             viewModelScope.launch {
@@ -326,6 +329,14 @@ class DiaryWriteViewModel @Inject constructor(
                 events.send(DiaryWriteEvent.ClearLocation)
             }
         }
+    }
+
+    fun showPermissionRequestDialog(permission : String) {
+        _requestPermissionSettingAction.update { permission }
+    }
+
+    fun dismissPermissionRequestDialog() {
+        _requestPermissionSettingAction.update { null }
     }
 
     private fun callGoBackNavigationEvent() {

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -126,7 +126,8 @@ fun DiaryWriteContainer(
         showLocationPickerDialog = viewModel::showLocationPickerDialog,
         hideLocationPickerDialog = viewModel::hideLocationPickerDialog,
         selectCityById = viewModel::selectCityById,
-        showPermissionDialog = viewModel::showPermissionRequestDialog
+        showPermissionDialog = viewModel::showPermissionRequestDialog,
+        disableLockScreen = viewModel::disableLockScreen
     )
 }
 
@@ -154,7 +155,8 @@ fun DiaryWriteScreen(
     showLocationPickerDialog : () -> Unit = {},
     hideLocationPickerDialog : () -> Unit = {},
     selectCityById : (Int?) -> Unit = {},
-    showPermissionDialog : (String) -> Unit = {}
+    showPermissionDialog : (String) -> Unit = {},
+    disableLockScreen : () -> Unit = {}
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -185,12 +187,18 @@ fun DiaryWriteScreen(
     }
 
     val requestWriteExternalStoragePermissionLauncherForImage = rememberSinglePermissionRequestLauncher(
-        onPermissionGranted = { prevPhotoPickerLauncher.launch("*/*") },
+        onPermissionGranted = {
+            disableLockScreen()
+            prevPhotoPickerLauncher.launch("*/*")
+        },
         onPermissionDenied = { showPermissionDialog(Settings.ACTION_APPLICATION_DETAILS_SETTINGS) }
     )
 
     val requestWriteExternalStoragePermissionLauncherForVoice = rememberSinglePermissionRequestLauncher(
-        onPermissionGranted = { mp3PickerLauncher.launch("audio/*") },
+        onPermissionGranted = {
+            disableLockScreen()
+            mp3PickerLauncher.launch("audio/*")
+        },
         onPermissionDenied = { showPermissionDialog(Settings.ACTION_APPLICATION_DETAILS_SETTINGS) }
     )
 
@@ -294,6 +302,7 @@ fun DiaryWriteScreen(
                             onClickDeleteButton = deleteImageFile,
                             onClickAddMedia = {
                                 if (isPhotoPickerAvailable()) {
+                                    disableLockScreen()
                                     photoPickerLauncher.launch(
                                         PickVisualMediaRequest(
                                             ActivityResultContracts.PickVisualMedia.ImageOnly
@@ -301,6 +310,7 @@ fun DiaryWriteScreen(
                                     )
                                 } else {
                                     if (WRITE_EXTERNAL_STORAGE_28 == null) {
+                                        disableLockScreen()
                                         prevPhotoPickerLauncher.launch("*/*")
                                     } else {
                                         requestWriteExternalStoragePermissionLauncherForImage.launch(WRITE_EXTERNAL_STORAGE_28)
@@ -354,6 +364,7 @@ fun DiaryWriteScreen(
                                     if (!state.buttonActive) return@EmptySoundView
 
                                     if (WRITE_EXTERNAL_STORAGE_28 == null) {
+                                        disableLockScreen()
                                         mp3PickerLauncher.launch("audio/*")
                                     } else {
                                         requestWriteExternalStoragePermissionLauncherForVoice.launch(WRITE_EXTERNAL_STORAGE_28)

--- a/presentation/src/main/java/com/strayalphaca/presentation/utils/PermissionUtils.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/utils/PermissionUtils.kt
@@ -3,8 +3,11 @@ package com.strayalphaca.presentation.utils
 import android.Manifest
 import android.app.AlarmManager
 import android.content.Context
-import android.content.pm.PackageManager
 import android.os.Build
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
 
 val EXACT_ALARM_PERMISSION = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
     Manifest.permission.SCHEDULE_EXACT_ALARM
@@ -30,11 +33,26 @@ val POST_NOTIFICATIONS_33 =
         null
     }
 
+val WRITE_EXTERNAL_STORAGE_28 = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+    Manifest.permission.WRITE_EXTERNAL_STORAGE
+} else {
+    null
+}
 
-fun checkPostNotificationAvailable(context: Context): Boolean {
-    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        context.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
-    } else {
-        true
-    }
+@Composable
+fun rememberSinglePermissionRequestLauncher(
+    onPermissionGranted : () -> Unit,
+    onPermissionDenied : () -> Unit
+) : ManagedActivityResultLauncher<String, Boolean> {
+    val requestWriteExternalStoragePermissionLauncherForVoice = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { granted ->
+            if (granted) {
+                onPermissionGranted()
+            } else {
+                onPermissionDenied()
+            }
+        }
+    )
+    return requestWriteExternalStoragePermissionLauncherForVoice
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -87,6 +87,7 @@
     <string name="no">아니요</string>
 
     <string name="deny_permission">권한 거부됨</string>
+    <string name="permission_description_write_external_storage_under_28">이미지 및 음성파일을 저장하기 위해서는 저장소 권한이 필요합니다.</string>
     <string name="permission_description_post_notification">알람 권한을 허용하지 않으면, 알람 표시기능을 사용할 수 없습니다.</string>
     <string name="go_to_app_setting">앱 설정 화면으로 이동하기 >></string>
     <string name="check">확인</string>


### PR DESCRIPTION
- Room 사용시 일지 작성 과정에서 파일을 externalStorage에 저장하기 위해 sdk_idx 28 이하의 기기에서 write_external_storage 권한을 요청하도록 수정
  - 단일 권한을 요청하는 부분을 rememberSinglePermissionRequestLauncher라는 별도의 함수로 분리 (PermissionUtils.kt)
- 일지 작성 화면에서 잠금화면이 설정되어 있을 때, 이미지 및 음성 파일을 선택할 때에도 잠금 화면이 호출되는 문제 수정
  - domain:lock 모듈에 잠금화면의 호출가능여부를 관리하는 LockScreenAvailabilityManager 클래스 정의
  - 이미지 및 음성 파일을 추가할 때 LockScreenAvailabilityManager의 disableLockScreen을 호출하여 잠금화면이 호출하지 않도록 구현
  - RootActivity에서 onStart시 lockScreen이 호출될 때, LockScreenAvailabilityManager의 lockScreenEnabled에 접근하여 현재 잠금화면을 호출할 수 있는지를 추가적으로 검사
  - 만약 lockScreenEnabled가 true면 기존 조건에 따라 lockScreen을 호출하지만, 만약 false인 경우 잠금화면을 아예 호출하지 않고 대신 LockScreenAvailability의 enableLockScreen을 호출
    - [일반적인 LockScreen 호출 흐름] 
       1. 홈 버튼 클릭
       2. 다시 앱으로 복귀시 onStart에서 잠금화면 호출
    - [이미지/음성파일 선택시] 
       1. 이미지/음성파일 선택 화면으로 이동하기 전 LockScreenAvailabilityManager.disableLockScreen() 호출
       2. 이미지/음성파일 선택 후 onStart에서 LockScreenAvailabilityManager.lockScreenEnabled 검사 (값은 false)
       3. LockScreenAvailabilityManager.lockScreenEnabled()를 호출하여 다시 잠금화면을 활성화