### PR TITLE
fix map

### DIFF
--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationWithData.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/LocationWithData.kt
@@ -3,4 +3,25 @@ package com.strayalphaca.travel_diary.map.model
 data class LocationWithData(
     val location : Location? = null,
     val data : List<LocationDiary> = emptyList()
-)
+) {
+    // 두 객체가 서로 다른 참조를 가지고 있고
+    // 두 객체 모두 location == null, data == emptyList 인 경우, false 리턴
+    override fun equals(other: Any?): Boolean {
+        if (
+            other !== this && // 반사성 체크
+            other is LocationWithData &&
+            (location == null && other.location == null) &&
+            (data.isEmpty() && other.data.isEmpty())
+        ) {
+            return false
+        }
+
+        return super.equals(other)
+    }
+
+    override fun hashCode(): Int {
+        var result = location?.hashCode() ?: 0
+        result = 31 * result + data.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
- 작성한 일지가 없는 경우, 간헐적으로 지도 화면에서 작성한 일지가 없다는 것을 알리는 UI가 표시되지 않는 문제 수정
  - 맵 데이터를 flow 형태로 가져오는 useCase를 collect하면 success로 상태를 업데이트하는 방식에서,
  상태 변화가 success -> loading -> success로 변경할 때, 첫 success를 발생하는 stateFlow의 value값과 마지막 success를 발생하는 stateFlow의 value값이 동일하게 되어, 마지막 success를 발생하는 stateFlow의 emit이 동작하지 않아 발생
  - 이를 해결하기 위해, 초기 상태인 경우, 서로 다른 주소값을 가진다면 무조건 equals에서 false를 리턴하도록 수정
  (초기 상태와 다른 프로퍼티값을 가진 경우(지도상 일지 데이터가 존재하는 상황)에서는 문제가 발생하지 않음)
