### PR TITLE
fix diary

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -10,8 +10,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.CircularProgressIndicator
@@ -35,7 +34,7 @@ import com.strayalphaca.presentation.ui.theme.Gray2
 import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -159,7 +158,6 @@ fun DiaryWriteScreen(
     disableLockScreen : () -> Unit = {}
 ) {
     val lifecycleOwner = LocalLifecycleOwner.current
-    val interactionSource = remember { MutableInteractionSource() }
     val focusManager = LocalFocusManager.current
 
     val photoPickerLauncher = if (3 - state.imageFiles.size > 1) {
@@ -235,11 +233,10 @@ fun DiaryWriteScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .clickable(
-                    interactionSource = interactionSource,
-                    indication = null
-                ) {
-                    focusManager.clearFocus()
+                .pointerInput(Unit) {
+                    detectTapGestures {
+                        focusManager.clearFocus()
+                    }
                 }
         ) {
             Row(


### PR DESCRIPTION
- 일지 작성 화면의 textField에서 문자를 입력하지 않은 경우 키보드의 줄넘김 버튼을 클릭하면 키보드가 숨겨지는 문제 수정
  -  column modifier의 clickable을 pointerInput을 사용하는 방식으로 수정