### PR TITLE
fix map

### DIFF
--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
@@ -17,15 +17,17 @@ class MapLocalDataSource @Inject constructor(
         val recordItemList = recordDao.getRecordInMapNationWide()
             .getSingleItemPerId()
             .groupBy { it.provinceId }.values
-            .firstOrNull()
+            .map {
+                it.first()
+            }
 
-        val response = recordItemList?.map { recordItem ->
+        val response = recordItemList.map { recordItem ->
             LocationDiary(
                 thumbnailUri = recordItem.fileUri,
                 location = Location.getInstanceByProvinceId(recordItem.provinceId!!),
                 id = recordItem.id.toString()
             )
-        } ?: emptyList()
+        }
         return BaseResponse.Success(data = response)
     }
 
@@ -33,9 +35,11 @@ class MapLocalDataSource @Inject constructor(
         val recordItemList = recordDao.getRecordInMapProvince(provinceId)
             .getSingleItemPerId()
             .groupBy { it.cityGroupId }.values
-            .firstOrNull()
+            .map {
+                it.first()
+            }
 
-        val response = recordItemList?.map { recordItem ->
+        val response = recordItemList.map { recordItem ->
             LocationDiary(
                 thumbnailUri = recordItem.fileUri,
                 location = Location(
@@ -46,7 +50,7 @@ class MapLocalDataSource @Inject constructor(
                 ),
                 id = recordItem.id.toString()
             )
-        } ?: emptyList()
+        }
         return BaseResponse.Success(data = response)
     }
 }


### PR DESCRIPTION
- 지도 화면에서 둘 이상의 위치가 한번에 표시되지 않는 문제 수정
  - 예를 들어, 서울 서초구로 위치를 지정한 일지를 작성한 후, 부산 북구로 지정한 일지 하나를 작성했을 때, 지도 화면에서 서울과 부산 지역에 일지가 표시되는 것이 아닌, 먼저 작성한 서울 외 나머지 지역에 일지가 표시되지 않던 문제가 발생함
  - groupby를 수행한 결과, Map<K, List<V>>의 리턴 값이 나오는데, 여기서 values를 사용한다면 List<List<V>> 타입의 객체가 리턴됨
    - 이 떄 List<List<T>의 원소인 List<T>는 한 지역에 대해 해당 지역으로 설정된 일지 리스트를 의미
  - 여기서 firstOrNull을 하게 됨으로써 처음 하나의 지역에 대한 일지 리스트만 불러오게 되어 다른 지역이 표시되지 않았음
  - 이를 map함수 내 first를 수행하도록 수정하여 해당 지역에 하나만 일지가 존재하도록 수정
  