### PR TITLE
fix diary

### DIFF
--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DirayWriteScreen.kt
@@ -299,7 +299,6 @@ fun DiaryWriteScreen(
                             onClickDeleteButton = deleteImageFile,
                             onClickAddMedia = {
                                 if (isPhotoPickerAvailable()) {
-                                    disableLockScreen()
                                     photoPickerLauncher.launch(
                                         PickVisualMediaRequest(
                                             ActivityResultContracts.PickVisualMedia.ImageOnly


### PR DESCRIPTION
- photoPicker를 사용가능한 기기에서 photoPicker를 통해 미디어 파일을 선택한 경우 잠금화면이 호출되지 않는 문제 수정
  - photoPicker를 사용해 미디어 파일을 선택한 경우, onStop이 발생하지 않는다. 하지만, 잠금화면 비활성화 변수를 설정하여 잠금화면이 표시되지 않음
  - 이로 인해, photoPicker를 사용한 이후 첫 onStart시에는 잠금화면이 표시되지 않음
  - 이를 수정하기 위해서 photoPicker를 호출할 때는 잠금화면 비활성화를 수행하지 않도록 해당 부분을 제거
