### PR TITLE
Feature camera

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,10 @@
     <uses-permission
         android:name="android.permission.POST_NOTIFICATIONS"
         android:minSdkVersion="33"/>
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA"/>
 
     <application
         android:allowBackup="false"

--- a/app/src/main/java/com/strayalphaca/travel_diary/RootDestination.kt
+++ b/app/src/main/java/com/strayalphaca/travel_diary/RootDestination.kt
@@ -67,3 +67,7 @@ object DiaryList : RootDestinations {
     val arguments = listOf(navArgument(cityGroupId){type = NavType.IntType})
     val deepLinks = listOf(navDeepLink { uriPattern = "traily://${route}/{${cityGroupId}}" })
 }
+
+object Camera : RootDestinations {
+    override val route: String = "camera"
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ exifinterface = "1.3.6"
 firebase_bom = "32.7.0"
 room = "2.5.2"
 work_version = "2.8.0"
+camera = "1.2.3"
 
 [libraries]
 android-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "ktx" }
@@ -102,6 +103,11 @@ roomCompiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 # work manager
 workruntime_ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work_version" }
 
+# cameraX
+camera_view = { group = "androidx.camera", name = "camera-view", version.ref = "camera" }
+camera_camera2 =  { group = "androidx.camera", name = "camera-camera2", version.ref = "camera" }
+camera_lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camera" }
+
 [bundles]
 okhttp3 = ["okhttp3-okhttp", "okhttp3-logging-interceptor"]
 retrofit2 = ["retrofit2-retrofit", "retrofit2-converter-gson"]
@@ -111,3 +117,4 @@ coil = ["coil", "coil-video", "coil-compose"]
 datastore = ["datastore", "datastore_core"]
 coroutine = ["coroutine", "coroutine_test"]
 room = ["roomKtx", "roomRuntime"]
+camera = ["camera_camera2", "camera_lifecycle", "camera_view"]

--- a/presentation/build.gradle
+++ b/presentation/build.gradle
@@ -101,6 +101,9 @@ dependencies {
 
     // exif interface
     implementation libs.exifinterface
+
+    // camerax
+    implementation libs.bundles.camera
 }
 
 kapt {

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/ImageSelectOptionDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/ImageSelectOptionDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -85,7 +86,8 @@ fun ImageSelectOptionDialog(
                     Image(
                         modifier = Modifier.size(48.dp),
                         painter = painterResource(id = R.drawable.ic_camera),
-                        contentDescription = "image_select_option_camera"
+                        contentDescription = "image_select_option_camera",
+                        colorFilter = ColorFilter.tint(color = MaterialTheme.colors.onSurface)
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))
@@ -119,7 +121,8 @@ fun ImageSelectOptionDialog(
                     Image(
                         modifier = Modifier.size(48.dp),
                         painter = painterResource(id = R.drawable.ic_image),
-                        contentDescription = "image_select_option_camera"
+                        contentDescription = "image_select_option_camera",
+                        colorFilter = ColorFilter.tint(color = MaterialTheme.colors.onSurface)
                     )
 
                     Spacer(modifier = Modifier.height(8.dp))

--- a/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/ImageSelectOptionDialog.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/components/template/dialog/ImageSelectOptionDialog.kt
@@ -1,0 +1,168 @@
+package com.strayalphaca.presentation.components.template.dialog
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.strayalphaca.presentation.R
+import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
+
+@Composable
+fun ImageSelectOptionDialog(
+    onDismissRequest : () -> Unit,
+    onCameraClick : () -> Unit,
+    onGalleryClick : () -> Unit
+) {
+
+    TapeDialog(onDismissRequest = onDismissRequest) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 12.dp)
+        ) {
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(id = R.string.select_image_option),
+                style = MaterialTheme.typography.body2,
+                color = MaterialTheme.colors.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(id = R.string.caption_select_image_option),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Column(
+                    modifier = Modifier
+                        .height(126.dp)
+                        .weight(1f)
+                        .border(
+                            width = 1.dp,
+                            shape = RectangleShape,
+                            color = MaterialTheme.colors.onSurface
+                        )
+                        .clickable {
+                            onDismissRequest()
+                            onCameraClick()
+                        },
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Image(
+                        modifier = Modifier.size(48.dp),
+                        painter = painterResource(id = R.drawable.ic_camera),
+                        contentDescription = "image_select_option_camera"
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = stringResource(id = R.string.take_picture_from_camera),
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(12.dp))
+
+                Column(
+                    modifier = Modifier
+                        .height(126.dp)
+                        .weight(1f)
+                        .border(
+                            width = 1.dp,
+                            shape = RectangleShape,
+                            color = MaterialTheme.colors.onSurface
+                        )
+                        .clickable {
+                            onDismissRequest()
+                            onGalleryClick()
+                        },
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Image(
+                        modifier = Modifier.size(48.dp),
+                        painter = painterResource(id = R.drawable.ic_image),
+                        contentDescription = "image_select_option_camera"
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = stringResource(id = R.string.get_from_gallery),
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.onSurface,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            TextButton(
+                modifier = Modifier.align(Alignment.End),
+                onClick = {
+                    onDismissRequest()
+                },
+                contentPadding = PaddingValues(8.dp)
+            ) {
+                Text(
+                    text = stringResource(id = R.string.cancel),
+                    style = MaterialTheme.typography.body2,
+                    color = MaterialTheme.colors.onSurface
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun ImageSelectOptionDialogPreview() {
+    TravelDiaryTheme() {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = Color.Magenta
+        ) {
+            ImageSelectOptionDialog(onDismissRequest = {}, onCameraClick = {}) {
+
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/uri_handler/FileHandler.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/uri_handler/FileHandler.kt
@@ -1,0 +1,32 @@
+package com.strayalphaca.presentation.models.uri_handler
+
+import android.content.Context
+import android.graphics.Bitmap
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.File
+import java.io.FileOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FileHandler @Inject constructor(
+    @ApplicationContext private val context : Context
+){
+    fun bitmapToFile(bitmap: Bitmap, fileName : String) : File? {
+        val externalStorageDir = context.getExternalFilesDir(null)
+        val fileDirPath = externalStorageDir?.absolutePath + File.separator + "medias"
+
+        File(fileDirPath).run {
+            if (!exists()) {
+                if (!mkdir()) return null
+            }
+        }
+
+        val file = File(fileDirPath, fileName)
+        FileOutputStream(file).use { outputStream ->
+            bitmap.compress(Bitmap.CompressFormat.JPEG, 100, outputStream)
+        }
+
+        return file
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/models/uri_handler/UriHandler.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/models/uri_handler/UriHandler.kt
@@ -3,6 +3,7 @@ package com.strayalphaca.presentation.models.uri_handler
 import android.content.Context
 import android.net.Uri
 import android.provider.MediaStore
+import android.webkit.MimeTypeMap
 
 import com.strayalphaca.travel_diary.domain.file.model.FileInfo
 import com.strayalphaca.travel_diary.domain.file.model.FileType
@@ -48,23 +49,30 @@ class UriHandler @Inject constructor(
     }
 
     fun getFileType(uri: Uri): FileType {
-        val mimeType = context.contentResolver.getType(uri) ?: return FileType.Unknown
+        val mimeType = context.contentResolver.getType(uri) ?: return getFileTypeByFileExtension(uri)
         return when {
             mimeType.contains("audio") -> {
                 FileType.Voice
             }
-
             mimeType.contains("image") -> {
                 FileType.Image
             }
-
             mimeType.contains("video") -> {
                 FileType.Video
             }
-
             else -> {
                 FileType.Unknown
             }
+        }
+    }
+
+    private fun getFileTypeByFileExtension(uri : Uri) : FileType {
+        val fileExtension = MimeTypeMap.getFileExtensionFromUrl(uri.toString())
+        return when(fileExtension) {
+            "jpg", "jpeg", "png" -> { FileType.Image }
+            "mp4", "webm" -> { FileType.Video }
+            "mp3", "wav" -> { FileType.Voice }
+            else -> { FileType.Unknown }
         }
     }
 

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
@@ -3,6 +3,7 @@ package com.strayalphaca.presentation.screens.camera
 import android.Manifest
 import android.content.res.Configuration
 import android.graphics.Bitmap
+import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -67,10 +68,12 @@ fun CameraScreenContainer(
     onBackPressWithResult : (String) -> Unit
 ) {
     var permissionGranted by remember { mutableStateOf(false) }
+    val context = LocalContext.current
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission(),
         onResult = { isGranted ->
             if (!isGranted) {
+                Toast.makeText(context, context.getString(R.string.permission_description_camera), Toast.LENGTH_SHORT).show()
                 onBackPress()
             }
             permissionGranted = isGranted

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
@@ -1,0 +1,207 @@
+package com.strayalphaca.presentation.screens.camera
+
+import android.Manifest
+import android.content.res.Configuration
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.camera.core.CameraSelector
+import androidx.camera.view.LifecycleCameraController
+import androidx.camera.view.PreviewView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.zIndex
+import com.strayalphaca.presentation.R
+import com.strayalphaca.presentation.ui.theme.Tape
+import com.strayalphaca.presentation.ui.theme.TravelDiaryTheme
+
+@Composable
+fun CameraScreenContainer(
+    onBackPress : () -> Unit
+) {
+    var permissionGranted by remember { mutableStateOf(false) }
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { isGranted ->
+            if (!isGranted) {
+                onBackPress()
+            }
+            permissionGranted = isGranted
+        }
+    )
+
+    LaunchedEffect(Unit) {
+        // 권한 확인 후 요청 혹은 화면 호출
+        cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+    }
+
+    if (permissionGranted) {
+        CameraScreen()
+    }
+}
+
+@Composable
+fun CameraScreen(
+
+) {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // lensFacing의 경우 추후 viewModel 내 state로 변경할 예정
+    val lensFacing = remember { CameraSelector.LENS_FACING_BACK }
+    val previewView = remember { PreviewView(context) }
+    val cameraController = remember { LifecycleCameraController(context) }
+
+    LaunchedEffect(lensFacing) {
+        cameraController.unbind()
+        cameraController.bindToLifecycle(lifecycleOwner)
+        cameraController.cameraSelector = CameraSelector.Builder().requireLensFacing(lensFacing).build()
+        previewView.controller = cameraController
+    }
+
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .zIndex(1f)
+                .align(Alignment.TopCenter)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Black,
+                            Color.Transparent
+                        )
+                    )
+                )
+                .padding(16.dp)
+        ) {
+            IconButton(
+                onClick = {  }
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_back),
+                    contentDescription = "back_button",
+                    modifier = Modifier
+                        .size(48.dp)
+                        .background(color = Color.White)
+                        .padding(2.dp)
+                        .border(width = 1.dp, shape = RectangleShape, color = Color.Black)
+                        .padding(10.dp)
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Tape)
+        ) {
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = { previewView }
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(120.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            Color.Black
+                        )
+                    )
+                ),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+
+            IconButton(
+                modifier = Modifier
+                    .size(64.dp)
+                    .background(Color.White, CircleShape),
+                onClick = {
+                    // 카메라 전환 기능
+                }
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .padding(18.dp),
+                    painter = painterResource(id = R.drawable.ic_change),
+                    contentDescription = "change_camera"
+                )
+            }
+
+            Spacer(modifier = Modifier.width(36.dp))
+
+            IconButton(
+                modifier = Modifier
+                    .size(80.dp)
+                    .background(Color.White, CircleShape),
+                onClick = {
+                    // 사진 촬영
+                }
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .size(72.dp)
+                        .border(width = 2.dp, color = Color.Black, shape = CircleShape)
+                        .padding(18.dp),
+                    painter = painterResource(id = R.drawable.ic_camera),
+                    contentDescription = "take_picture"
+                )
+            }
+
+            Spacer(modifier = Modifier.width(90.dp))
+
+        }
+    }
+}
+
+@Composable
+@Preview(
+    showBackground = true,
+    widthDp = 360,
+    uiMode = Configuration.UI_MODE_NIGHT_YES,
+    name = "dark"
+)
+@Preview(showBackground = true, widthDp = 360)
+fun CameraScreenPreview(){
+    TravelDiaryTheme {
+        CameraScreen()
+    }
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
@@ -63,7 +63,8 @@ import com.strayalphaca.presentation.utils.collectAsEffect
 @Composable
 fun CameraScreenContainer(
     viewModel : CameraViewModel,
-    onBackPress : () -> Unit
+    onBackPress : () -> Unit,
+    onBackPressWithResult : (String) -> Unit
 ) {
     var permissionGranted by remember { mutableStateOf(false) }
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
@@ -82,7 +83,7 @@ fun CameraScreenContainer(
         if (photoUri == null) {
             onBackPress()
         } else {
-            // 인자 추가된 onBackPress 구현
+            onBackPressWithResult(photoUri.toString())
         }
     }
 
@@ -99,7 +100,8 @@ fun CameraScreenContainer(
             cameraScreenState = cameraScreenState,
             showTakenImage = viewModel::takePhoto,
             onBackPress = onBackPress,
-            backToCamera = viewModel::moveToCameraState
+            backToCamera = viewModel::moveToCameraState,
+            confirmImage = viewModel::confirmPhoto
         )
     }
 }
@@ -110,6 +112,7 @@ fun CameraScreen(
     showTakenImage : (Bitmap) -> Unit,
     onBackPress: () -> Unit,
     backToCamera : () -> Unit,
+    confirmImage : () -> Unit
 ) {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -271,10 +274,13 @@ fun CameraScreen(
                     contentDescription = "captured photo"
                 )
 
-                Row(modifier = Modifier.fillMaxWidth()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
                     TextButton(
                         onClick = { backToCamera() },
-                        modifier = Modifier.fillMaxWidth().weight(1f)
+                        modifier = Modifier.weight(1f).padding(vertical = 8.dp)
                     ) {
                         Text(text = stringResource(id = R.string.retake_photo), color = Color.White)
                     }
@@ -285,8 +291,8 @@ fun CameraScreen(
                     )
 
                     TextButton(
-                        onClick = {  },
-                        modifier = Modifier.weight(1f)
+                        onClick = { confirmImage() },
+                        modifier = Modifier.weight(1f).padding(vertical = 8.dp)
                     ) {
                         Text(text = stringResource(id = R.string.confirmation_this_photo), color = Color.White)
                     }
@@ -311,7 +317,8 @@ fun CameraScreenPreview(){
             cameraScreenState = CameraScreenState.Camera,
             showTakenImage = {},
             onBackPress = {},
-            backToCamera = {}
+            backToCamera = {},
+            confirmImage = {}
         )
     }
 }

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraScreen.kt
@@ -196,10 +196,9 @@ fun CameraScreen(
                     .size(64.dp)
                     .background(Color.White, CircleShape),
                 onClick = {
-                    // 카메라 전환 기능
-                    lensFacing = if (lensFacing == CameraSelector.LENS_FACING_BACK)
-                        CameraSelector.LENS_FACING_FRONT
-                    else
+                    if (lensFacing == CameraSelector.LENS_FACING_BACK && cameraController.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA))
+                        lensFacing = CameraSelector.LENS_FACING_FRONT
+                    else if (lensFacing == CameraSelector.LENS_FACING_FRONT && cameraController.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA))
                         CameraSelector.LENS_FACING_BACK
                 }
             ) {
@@ -255,19 +254,22 @@ fun CameraScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(Color.Black)
-                    .zIndex(1f)
+                    .zIndex(1f),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                IconButton(
-                    onClick = { backToCamera() }
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_close),
-                        contentDescription = "back_to_camera_button",
-                        modifier = Modifier
-                            .size(48.dp)
-                            .padding(12.dp),
-                        tint = Color.White
-                    )
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    IconButton(
+                        onClick = { backToCamera() }
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_close),
+                            contentDescription = "back_to_camera_button",
+                            modifier = Modifier
+                                .size(48.dp)
+                                .padding(12.dp),
+                            tint = Color.White
+                        )
+                    }
                 }
 
                 Image(

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraViewModel.kt
@@ -3,17 +3,26 @@ package com.strayalphaca.presentation.screens.camera
 import android.graphics.Bitmap
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.strayalpaca.travel_diary.core.domain.model.BaseResponse
 import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
 import com.strayalphaca.presentation.models.event_flow.asEventFlow
+import com.strayalphaca.presentation.models.uri_handler.FileHandler
+import com.strayalphaca.travel_diary.domain.file.model.FileInfo
+import com.strayalphaca.travel_diary.domain.file.model.FileType
+import com.strayalphaca.travel_diary.domain.file.usecase.UseCaseUploadFiles
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.util.Calendar
 import javax.inject.Inject
 
+@HiltViewModel
 class CameraViewModel @Inject constructor(
-
+    private val useCaseUploadFiles: UseCaseUploadFiles,
+    private val fileHandler: FileHandler
 ) : ViewModel() {
 
     private val _screenState = MutableStateFlow<CameraScreenState>(CameraScreenState.Camera)
@@ -31,13 +40,16 @@ class CameraViewModel @Inject constructor(
     }
     
     fun onBackPressed() {
-        when (screenState.value) {
+        val currentScreenState = screenState.value
+
+        when (currentScreenState) {
             is CameraScreenState.Camera -> {
                 viewModelScope.launch {
                     _moveToBackStack.emit(null)
                 }
             }
             is CameraScreenState.PhotoConfirmation -> {
+                currentScreenState.bitmap.recycle()
                 moveToCameraState()
             }
         }
@@ -45,7 +57,23 @@ class CameraViewModel @Inject constructor(
 
     // 사진 확인에서 확정 버튼 클릭
     fun confirmPhoto() {
+        val currentState = screenState.value
+        if (currentState !is CameraScreenState.PhotoConfirmation) return
 
+        viewModelScope.launch {
+            // bitmap 을 file로 변경
+            val fileName = "${Calendar.getInstance().timeInMillis}.jpg"
+            val file = fileHandler.bitmapToFile(currentState.bitmap, fileName) ?: return@launch
+
+            // useCaseUploadFile 가 List<FileInfo>를 인자로 받기 때문에 이를 위한 작업
+            val fileInfos = listOf(file).map { FileInfo(file, FileType.Image) }
+            val response = useCaseUploadFiles(fileInfos)
+
+            if (response is BaseResponse.Success<List<String>>) {
+                if (response.data.isNotEmpty())
+                    _moveToBackStack.emit(file.path)
+            }
+        }
     }
 
     // 카메라 화면에서 사진 촬영 클릭

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/CameraViewModel.kt
@@ -1,0 +1,62 @@
+package com.strayalphaca.presentation.screens.camera
+
+import android.graphics.Bitmap
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.strayalphaca.presentation.models.event_flow.MutableEventFlow
+import com.strayalphaca.presentation.models.event_flow.asEventFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class CameraViewModel @Inject constructor(
+
+) : ViewModel() {
+
+    private val _screenState = MutableStateFlow<CameraScreenState>(CameraScreenState.Camera)
+    val screenState : StateFlow<CameraScreenState> = _screenState.asStateFlow()
+
+    private val _moveToBackStack = MutableEventFlow<String?>()
+    val moveToBackStack = _moveToBackStack.asEventFlow()
+
+    // 사진 확인 화면에서 이전 카메라 화면으로 돌아가는 경우
+    fun moveToCameraState() {
+        _screenState.update {
+            if (it is CameraScreenState.Camera) { it }
+            else { CameraScreenState.Camera }
+        }
+    }
+    
+    fun onBackPressed() {
+        when (screenState.value) {
+            is CameraScreenState.Camera -> {
+                viewModelScope.launch {
+                    _moveToBackStack.emit(null)
+                }
+            }
+            is CameraScreenState.PhotoConfirmation -> {
+                moveToCameraState()
+            }
+        }
+    }
+
+    // 사진 확인에서 확정 버튼 클릭
+    fun confirmPhoto() {
+
+    }
+
+    // 카메라 화면에서 사진 촬영 클릭
+    fun takePhoto(bitmap : Bitmap) {
+        _screenState.update {
+            CameraScreenState.PhotoConfirmation(bitmap)
+        }
+    }
+}
+
+sealed interface CameraScreenState {
+    object Camera : CameraScreenState
+    data class PhotoConfirmation(val bitmap: Bitmap) : CameraScreenState // bitmap이 아닐 수도?
+}

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/util/ImageCaptureUtil.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/camera/util/ImageCaptureUtil.kt
@@ -1,0 +1,22 @@
+package com.strayalphaca.presentation.screens.camera.util
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Matrix
+import androidx.camera.core.ImageProxy
+
+// 이미지 포맷에 따라 다르게 구현해야 할 가능성 존재
+fun imageProxyToBitmap(imageProxy: ImageProxy) : Bitmap {
+    val rotateDegree = imageProxy.imageInfo.rotationDegrees
+
+    val imageBuffer = imageProxy.planes[0].buffer
+    val bytes = ByteArray(imageBuffer.remaining())
+    imageBuffer.get(bytes)
+
+    imageProxy.close()
+    return BitmapFactory.decodeByteArray(bytes, 0, bytes.size).rotate(rotateDegree.toFloat())
+}
+
+internal fun Bitmap.rotate(degree : Float) : Bitmap = Bitmap.createBitmap(this, 0, 0, width, height, Matrix().apply { postRotate(degree) }, true)
+
+internal fun Bitmap.reverseHorizontal() : Bitmap = Bitmap.createBitmap(this, 0, 0, width, height, Matrix().apply { setScale(-1f, 1f) }, false)

--- a/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
+++ b/presentation/src/main/java/com/strayalphaca/presentation/screens/diary/write/DiaryWriteViewModel.kt
@@ -390,6 +390,18 @@ class DiaryWriteViewModel @Inject constructor(
         lockScreenAvailabilityManager.disableLockScreen()
     }
 
+    fun showPhotoOptionDialog() {
+        viewModelScope.launch {
+            events.send(DiaryWriteEvent.SetShowPhotoOptionDialog(true))
+        }
+    }
+
+    fun dismissPhotoOptionDialog() {
+        viewModelScope.launch {
+            events.send(DiaryWriteEvent.SetShowPhotoOptionDialog(false))
+        }
+    }
+
     private fun reduce(state: DiaryWriteState, events: DiaryWriteEvent): DiaryWriteState {
         return when (events) {
             DiaryWriteEvent.DiaryLoading -> {
@@ -481,6 +493,9 @@ class DiaryWriteViewModel @Inject constructor(
             DiaryWriteEvent.MusicLoadingFail -> {
                 state.copy(musicError = true)
             }
+            is DiaryWriteEvent.SetShowPhotoOptionDialog -> {
+                state.copy(showPhotoOptionDialog = events.show)
+            }
         }
     }
 
@@ -509,6 +524,7 @@ sealed class DiaryWriteEvent {
     object ClearLocation : DiaryWriteEvent()
     class SetDiaryDate(val diaryDate: DiaryDate) : DiaryWriteEvent()
     object MusicLoadingFail : DiaryWriteEvent()
+    class SetShowPhotoOptionDialog(val show : Boolean) : DiaryWriteEvent()
 }
 
 data class DiaryWriteState(
@@ -525,5 +541,6 @@ data class DiaryWriteState(
     val cityName : String ?= null,
     val cityId : Int ?= null,
     val diaryDate: DiaryDate = DiaryDate.getInstanceFromCalendar(),
-    val musicError : Boolean = false
+    val musicError : Boolean = false,
+    val showPhotoOptionDialog : Boolean = false
 )

--- a/presentation/src/main/res/drawable/ic_camera.xml
+++ b/presentation/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M20,4h-3.17L15,2L9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,18L4,18L4,6h4.05l1.83,-2h4.24l1.83,2L20,6v12zM12,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5 5,-2.24 5,-5 -2.24,-5 -5,-5zM12,15c-1.65,0 -3,-1.35 -3,-3s1.35,-3 3,-3 3,1.35 3,3 -1.35,3 -3,3z"/>
+</vector>

--- a/presentation/src/main/res/drawable/ic_change.xml
+++ b/presentation/src/main/res/drawable/ic_change.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M12,6v3l4,-4 -4,-4v3c-4.42,0 -8,3.58 -8,8 0,1.57 0.46,3.03 1.24,4.26L6.7,14.8c-0.45,-0.83 -0.7,-1.79 -0.7,-2.8 0,-3.31 2.69,-6 6,-6zM18.76,7.74L17.3,9.2c0.44,0.84 0.7,1.79 0.7,2.8 0,3.31 -2.69,6 -6,6v-3l-4,4 4,4v-3c4.42,0 8,-3.58 8,-8 0,-1.57 -0.46,-3.03 -1.24,-4.26z"/>
+</vector>

--- a/presentation/src/main/res/values/strings_camera.xml
+++ b/presentation/src/main/res/values/strings_camera.xml
@@ -7,4 +7,7 @@
     <string name="take_picture_from_camera">카메라로\n촬영하기</string>
 
     <string name="permission_description_camera">사진 촬영을 위해서는 카메라 권한이 필요합니다.</string>
+    
+    <string name="confirmation_this_photo">이 사진으로 결정하기</string>
+    <string name="retake_photo">다시 촬영하기</string>
 </resources>

--- a/presentation/src/main/res/values/strings_camera.xml
+++ b/presentation/src/main/res/values/strings_camera.xml
@@ -5,4 +5,6 @@
 
     <string name="get_from_gallery">갤러리에서\n가져오기</string>
     <string name="take_picture_from_camera">카메라로\n촬영하기</string>
+
+    <string name="permission_description_camera">사진 촬영을 위해서는 카메라 권한이 필요합니다.</string>
 </resources>

--- a/presentation/src/main/res/values/strings_camera.xml
+++ b/presentation/src/main/res/values/strings_camera.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="select_image_option">이미지 선택 방법</string>
+    <string name="caption_select_image_option">이미지를 가져올 방법을 선택해주세요</string>
+
+    <string name="get_from_gallery">갤러리에서\n가져오기</string>
+    <string name="take_picture_from_camera">카메라로\n촬영하기</string>
+</resources>


### PR DESCRIPTION
카메라 화면 추가
- 일지 작성시 이미지 추가 클릭시 기존 이미지 선택 화면 (갤러리)로 이동하는 대신, 갤러리/카메라 선택 다이럴로그 표시
- CameraX 사용한 카메라 화면 구현
- 촬영한 사진의 경우, 로컬 스토리지에 저장된 후 로컬 스토리지에 저장한 사진의 경로를 이전 화면(일지 작성 화면)에 전달하는 방식
  - 촬영만 하고 일지를 저장하지 않았을 경우에는, 이전에 구현한 WorkManager에서 사진을 주기적으로 제거하여 불필요한 사진 파일이 저장되는 일은 없음
