### PR TITLE
Fix map

### DIFF
--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/dao/RecordDao.kt
@@ -33,7 +33,6 @@ interface RecordDao {
     suspend fun updateRecord(id : Int, content : String, weather : String, feeling : String, locationId : Int?)
 
     // 달력 일지 조회
-    // 이게 문제다, join을 해서, 동일한 id를 가진 일지가 여러개 생긴 거다.
     @Query(
         "SELECT r.id, r.createdAt as date, f.filePath as fileUri, r.locationId as locationId, f.type as fileType FROM RecordEntity r " +
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
@@ -68,7 +67,8 @@ interface RecordDao {
         "LEFT JOIN RecordFileEntity rf ON r.id = rf.recordId " +
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
-        "WHERE l.id = :cityId AND ( rf.positionInRecord = 0 OR rf.positionInRecord is null )" +
+        "WHERE l.id = :cityId AND ( rf.positionInRecord = 0 OR rf.positionInRecord is null ) " +
+        "ORDER BY r.createdAt DESC " +
         "LIMIT :perPage OFFSET (:pageIdx - 1) * :perPage"
     )
     suspend fun getRecordListInCity(cityId : Int, pageIdx : Int, perPage : Int): List<RecordItem>
@@ -80,6 +80,7 @@ interface RecordDao {
         "LEFT JOIN FileEntity f on rf.fileId = f.id " +
         "INNER JOIN LocationEntity l on r.locationId = l.id " +
         "WHERE l.cityGroupId = :cityGroupId AND ( rf.positionInRecord = 0 OR rf.positionInRecord is null )" +
+        "ORDER BY r.createdAt DESC " +
         "LIMIT :perPage OFFSET (:pageIdx - 1) * :perPage"
     )
     suspend fun getRecordListInCityGroup(cityGroupId : Int, pageIdx : Int, perPage : Int) : List<RecordItem>

--- a/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
+++ b/core/data/src/main/java/com/strayalphaca/travel_diary/core/data/room/model/RecordItem.kt
@@ -27,5 +27,4 @@ fun List<RecordItem>.getSingleItemPerId() : List<RecordItem> {
     return this.groupBy { it.id }
         .map { it.value.sortedWith(RecordItem.recordItemComparatorOnSameId).first() }
         .map { if (it.fileType == "Voice") it.copy(fileUri = null) else it } // 일지 아이템에서는 음성 파일 링크는 사용되지 않으므로 null로 변경
-        .sortedBy { it.date }
 }

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
@@ -8,6 +8,7 @@ import com.strayalphaca.travel_diary.map.model.Location
 import com.strayalphaca.travel_diary.map.model.LocationDiary
 import com.strayalphaca.travel_diary.map.model.LocationId
 import com.strayalphaca.travel_diary.map.model.LocationType
+import com.strayalphaca.travel_diary.map.model.Province
 import javax.inject.Inject
 
 class MapLocalDataSource @Inject constructor(
@@ -32,7 +33,10 @@ class MapLocalDataSource @Inject constructor(
     }
 
     override suspend fun getDiaryListInProvince(provinceId: Int): BaseResponse<List<LocationDiary>> {
-        val recordItemList = recordDao.getRecordInMapProvince(provinceId)
+        val recordItemList = Province.getSameGroupProvinceList(Province.findProvince(provinceId))
+            .map { it.id }
+            .map { recordDao.getRecordInMapProvince(it) }
+            .flatten()
             .getSingleItemPerId()
             .groupBy { it.cityGroupId }.values
             .map {

--- a/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
+++ b/data/map/src/main/java/com/strayalphaca/travel_diary/data/map/data_source/MapLocalDataSource.kt
@@ -17,10 +17,12 @@ class MapLocalDataSource @Inject constructor(
     override suspend fun getDiaryListInNationWide(): BaseResponse<List<LocationDiary>> {
         val recordItemList = recordDao.getRecordInMapNationWide()
             .getSingleItemPerId()
-            .groupBy { it.provinceId }.values
-            .map {
-                it.first()
-            }
+            .groupBy {
+                it.provinceId?.let { provinceId ->
+                    Province.findProvince(provinceId).group
+                }
+            }.values
+            .map { recordItemList -> recordItemList.maxBy { it.date } }
 
         val response = recordItemList.map { recordItem ->
             LocationDiary(
@@ -39,9 +41,7 @@ class MapLocalDataSource @Inject constructor(
             .flatten()
             .getSingleItemPerId()
             .groupBy { it.cityGroupId }.values
-            .map {
-                it.first()
-            }
+            .map { recordItemList -> recordItemList.maxBy{ it.date } }
 
         val response = recordItemList.map { recordItem ->
             LocationDiary(

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/Province.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/Province.kt
@@ -1,24 +1,24 @@
 package com.strayalphaca.travel_diary.map.model
 
 sealed class Province(val id: Int, val name: String, val group : Int = id) {
-    object Seoul : Province(PROVINCE_SEOUL, "서울특별시")
-    object Busan : Province(PROVINCE_BUSAN, "부산광역시")
-    object Daegu : Province(PROVINCE_DAEGU, "대구광역시")
-    object Incheon : Province(PROVINCE_INCHEON, "인천광역시")
-    object Gwangju : Province(PROVINCE_GWANGJU, "광주광역시")
-    object Daejeon : Province(PROVINCE_DAEJEON, "대전광역시")
-    object Ulsan : Province(PROVINCE_ULSAN, "울산광역시")
-    object Sejong : Province(PROVINCE_SEJONG, "세종특별자치시")
-    object Gyeonggi : Province(PROVINCE_Gyeonggi, "경기도")
-    object Gangwon : Province(PROVINCE_Gangwon, "강원도")
-    object Chungcheongbuk : Province(PROVINCE_Chungcheongbuk, "충청북도")
-    object Chungcheongnam : Province(PROVINCE_Chungcheongnam, "충청남도")
-    object Jeollabuk : Province(PROVINCE_Jeollabuk, "전라북도")
-    object Jeollanam : Province(PROVINCE_Jeollanam, "전라남도")
-    object Gyeongsangbuk : Province(PROVINCE_Gyeongsangbuk, "경상북도")
-    object Gyeongsangnam : Province(PROVINCE_Gyeongsangnam, "경상남도")
-    object Jeju : Province(PROVINCE_Jeju, "제주특별자치도")
-    object Ulreung : Province(PROVINCE_Ulreung, "울릉도/독도")
+    object Seoul : Province(PROVINCE_SEOUL, "서울특별시", PROVINCE_GROUP_SEOUL_INCHEON_Gyeonggi)
+    object Busan : Province(PROVINCE_BUSAN, "부산광역시", PROVINCE_GROUP_BUSAN_ULSAN_Gyeongsangnam)
+    object Daegu : Province(PROVINCE_DAEGU, "대구광역시", PROVINCE_GROUP_DAEGU_Gyeongsangbuk)
+    object Incheon : Province(PROVINCE_INCHEON, "인천광역시", PROVINCE_GROUP_SEOUL_INCHEON_Gyeonggi)
+    object Gwangju : Province(PROVINCE_GWANGJU, "광주광역시", PROVINCE_GROUP_GWANGJU_Jeollanam)
+    object Daejeon : Province(PROVINCE_DAEJEON, "대전광역시", PROVINCE_GROUP_DAEJEON_SEJONG_Chungcheongnam)
+    object Ulsan : Province(PROVINCE_ULSAN, "울산광역시", PROVINCE_GROUP_BUSAN_ULSAN_Gyeongsangnam)
+    object Sejong : Province(PROVINCE_SEJONG, "세종특별자치시", PROVINCE_GROUP_DAEJEON_SEJONG_Chungcheongnam)
+    object Gyeonggi : Province(PROVINCE_Gyeonggi, "경기도", PROVINCE_GROUP_SEOUL_INCHEON_Gyeonggi)
+    object Gangwon : Province(PROVINCE_Gangwon, "강원도", PROVINCE_GROUP_Gangwon)
+    object Chungcheongbuk : Province(PROVINCE_Chungcheongbuk, "충청북도", PROVINCE_GROUP_Chungcheongbuk)
+    object Chungcheongnam : Province(PROVINCE_Chungcheongnam, "충청남도", PROVINCE_GROUP_DAEJEON_SEJONG_Chungcheongnam)
+    object Jeollabuk : Province(PROVINCE_Jeollabuk, "전라북도", PROVINCE_GROUP_Jeollabuk)
+    object Jeollanam : Province(PROVINCE_Jeollanam, "전라남도", PROVINCE_GROUP_GWANGJU_Jeollanam)
+    object Gyeongsangbuk : Province(PROVINCE_Gyeongsangbuk, "경상북도", PROVINCE_GROUP_DAEGU_Gyeongsangbuk)
+    object Gyeongsangnam : Province(PROVINCE_Gyeongsangnam, "경상남도", PROVINCE_GROUP_BUSAN_ULSAN_Gyeongsangnam)
+    object Jeju : Province(PROVINCE_Jeju, "제주특별자치도", PROVINCE_GROUP_Jeju)
+    object Ulreung : Province(PROVINCE_Ulreung, "울릉도/독도", PROVINCE_GROUP_Ulreung)
     companion object {
         private fun listOfProvince() = Province::class.sealedSubclasses.toSet()
 
@@ -27,8 +27,8 @@ sealed class Province(val id: Int, val name: String, val group : Int = id) {
                 ?: throw IllegalArgumentException("Cannot find province which id is : $provinceId")
         }
 
-        fun getSameGroupProvinceList(groupId : Int) : List<Province> {
-            return listOfProvince().filter { it.objectInstance?.group == groupId }.mapNotNull { it.objectInstance }
+        fun getSameGroupProvinceList(province: Province) : List<Province> {
+            return listOfProvince().filter { it.objectInstance?.group == province.group }.mapNotNull { it.objectInstance }
         }
 
         fun getTotalProvinceList() : List<Province> {

--- a/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/const.kt
+++ b/domain/map/src/main/java/com/strayalphaca/travel_diary/map/model/const.kt
@@ -18,3 +18,14 @@ const val PROVINCE_Gyeongsangbuk = 15
 const val PROVINCE_Gyeongsangnam = 16
 const val PROVINCE_Jeju = 17
 const val PROVINCE_Ulreung = 18
+
+const val PROVINCE_GROUP_SEOUL_INCHEON_Gyeonggi = PROVINCE_SEOUL
+const val PROVINCE_GROUP_BUSAN_ULSAN_Gyeongsangnam = PROVINCE_BUSAN
+const val PROVINCE_GROUP_DAEGU_Gyeongsangbuk = PROVINCE_DAEGU
+const val PROVINCE_GROUP_GWANGJU_Jeollanam = PROVINCE_GWANGJU
+const val PROVINCE_GROUP_DAEJEON_SEJONG_Chungcheongnam = PROVINCE_DAEJEON
+const val PROVINCE_GROUP_Gangwon = PROVINCE_Gangwon
+const val PROVINCE_GROUP_Chungcheongbuk = PROVINCE_Chungcheongbuk
+const val PROVINCE_GROUP_Jeollabuk = PROVINCE_Jeollabuk
+const val PROVINCE_GROUP_Jeju = PROVINCE_Jeju
+const val PROVINCE_GROUP_Ulreung = PROVINCE_Ulreung


### PR DESCRIPTION
지도 화면 데이터 표시 부분 수정
- 동일한 Province Group내 여러 일지 데이터가 존재할 경우, Province Group에 속한 위치들 중, 가장 먼저 작성된 일지의 Province에만 데이터가 표시되는 문제 수정
  - 예시) 지도 화면에서 [서울, 인천, 경기도] 부분을 표시할 때, 아래와 같은 데이터가 존재한다고 가정
    - 2024년 3월 5일에 서울 지역으로 작성한 일지
    - 2024년 4월 10일에 인천 지역으로 작성한 일지  

   이 경우, [서울, 인천, 경기도] 부분을 표시하는 화면에서 위 데이터 중 가장 먼저 작성된 서울 지역만 일지 데이터가 표시되고 나머지 지역은 표시되지 않음

지역별 일지 리스트 표시 부분 수정
- 기존 오래된 순서로 표시되었던 부분을 최신순으로 표시되도록 수정